### PR TITLE
Fix indentations in celery plugin_health_check.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 /dist
 *.egg-info
 .DS_Store
+/build
+*#
+*~

--- a/health_check_celery/plugin_health_check.py
+++ b/health_check_celery/plugin_health_check.py
@@ -7,15 +7,15 @@ from time import sleep
 class CeleryHealthCheck(BaseHealthCheckBackend):
 
     def check_status(self):
-		try:
-	        result = add.apply_async(args=[4,4], expires=datetime.now() + timedelta(seconds=3), connect_timeout=3)
-	        now = datetime.now()
-	        while (now + timedelta(seconds=3)) > datetime.now():
-	            if result.result == 8:
-	                return HealthCheckStatusType.working
-	            sleep(0.5)
-		except IOError:
-			pass
+        try:
+            result = add.apply_async(args=[4,4], expires=datetime.now() + timedelta(seconds=3), connect_timeout=3)
+            now = datetime.now()
+            while (now + timedelta(seconds=3)) > datetime.now():
+                if result.result == 8:
+                    return HealthCheckStatusType.working
+                sleep(0.5)
+        except IOError:
+            pass
         return HealthCheckStatusType.unavailable
 
 plugin_dir.register(CeleryHealthCheck)


### PR DESCRIPTION
I fixed that, I also added /build, *~ and *# to .gitignore
