### PR TITLE
Added health_check.utils.healthcheck

### DIFF
--- a/health_check/utils.py
+++ b/health_check/utils.py
@@ -6,21 +6,8 @@ from health_check.plugins import plugin_dir
 
 class BaseHealthCheck(BaseHealthCheckBackend):
     def check_status(self):
-        try:
-            self._wrapped()
-        except HealthCheckFailed:
-            return HealthCheckStatusType.unexpected_result
-        except HealthCheckUnavailable:
-            return HealthCheckStatusType.unavailable
-        except:
-            return HealthCheckStatusType.unexpected_result
+        self._wrapped()
         return HealthCheckStatusType.working
-
-class HealthCheckFailed(Exception):
-    pass
-
-class HealthCheckUnavailable(Exception):
-    pass
 
 
 def healtcheck(func_or_name):
@@ -30,12 +17,12 @@ def healtcheck(func_or_name):
         @healthcheck("My Check")
         def my_check():
             if something_is_not_okay():
-                raise HealthCheckFailed()
+                raise ServiceReturnedUnexpectedResult()
 
         @healthcheck
         def other_check():
             if something_is_not_available():
-                raise HealthCHeckUnavailable()
+                raise ServiceUnavailable()
     """
     def inner(func):
         cls = type(func.__name__, (BaseHealthCheck,), {'_wrapped': func})

--- a/health_check/utils.py
+++ b/health_check/utils.py
@@ -10,7 +10,7 @@ class BaseHealthCheck(BaseHealthCheckBackend):
         return HealthCheckStatusType.working
 
 
-def healtcheck(func_or_name):
+def healthcheck(func_or_name):
     """
     Usage:
 
@@ -25,7 +25,7 @@ def healtcheck(func_or_name):
                 raise ServiceUnavailable()
     """
     def inner(func):
-        cls = type(func.__name__, (BaseHealthCheck,), {'_wrapped': func})
+        cls = type(func.__name__, (BaseHealthCheck,), {'_wrapped': staticmethod(func)})
         cls.identifier = name
         plugin_dir.register(cls)
         return func

--- a/health_check/utils.py
+++ b/health_check/utils.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from django.db.models.options import get_verbose_name
+from health_check.backends.base import HealthCheckStatusType, BaseHealthCheckBackend
+from health_check.plugins import plugin_dir
+
+
+class BaseHealthCheck(BaseHealthCheckBackend):
+    def check_status(self):
+        try:
+            self._wrapped()
+        except HealthCheckFailed:
+            return HealthCheckStatusType.unexpected_result
+        except HealthCheckUnavailable:
+            return HealthCheckStatusType.unavailable
+        except:
+            return HealthCheckStatusType.unexpected_result
+        return HealthCheckStatusType.working
+
+class HealthCheckFailed(Exception):
+    pass
+
+class HealthCheckUnavailable(Exception):
+    pass
+
+
+def healtcheck(func_or_name):
+    """
+    Usage:
+
+        @healthcheck("My Check")
+        def my_check():
+            if something_is_not_okay():
+                raise HealthCheckFailed()
+
+        @healthcheck
+        def other_check():
+            if something_is_not_available():
+                raise HealthCHeckUnavailable()
+    """
+    def inner(func):
+        cls = type(func.__name__, (BaseHealthCheck,), {'_wrapped': func})
+        cls.identifier = name
+        plugin_dir.register(cls)
+        return func
+    if callable(func_or_name):
+        name = get_verbose_name(func_or_name.__name__).replace('_', ' ')
+        return inner(func_or_name)
+    else:
+        name = func_or_name
+        return inner

--- a/health_check/utils.py
+++ b/health_check/utils.py
@@ -7,7 +7,7 @@ from health_check.plugins import plugin_dir
 class BaseHealthCheck(BaseHealthCheckBackend):
     def check_status(self):
         self._wrapped()
-        return HealthCheckStatusType.working
+        return True
 
 
 def healthcheck(func_or_name):


### PR DESCRIPTION
Added a decorator that makes it a lot easier to write checks. Inside the
decorator you can raise health_check.utils.HealthCheckFailed or
health_check.utils.HealthCheckUnavailable instead of returning
status values.
The decorator optionally accepts a string with a descriptive name of the
check.
