### PR TITLE
Django 1.6 compatibility

### DIFF
--- a/health_check/urls.py
+++ b/health_check/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, include, url
+from django.conf.urls import patterns, include, url
 
 import health_check
 health_check.autodiscover()


### PR DESCRIPTION
django.conf.urls.defaults was removed with django 1.6
