### PR TITLE
Make django-health-check 1.6 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-django-health-check
+django-health-check - Django 1.6 compatible
+==================
+
+This project is only a simple fork of http://kristianoellegaard.github.com/django-health-check/
+Pull requests were submitted to make it Django 1.6 compatible, not included for now.
+
 ==================
 
 This project checks a number of backends, if they are able to connect and do a simple action, e.g. check out the django ORM backend:

--- a/README.md
+++ b/README.md
@@ -75,5 +75,5 @@ Dependencies
 
 Python 2.7+ (Yes, thats right, we have **Python 3 support**)
 
-Django 1.2+
+Django 1.6+
 

--- a/health_check/urls.py
+++ b/health_check/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, include, url
+from django.conf.urls import patterns, include, url
 
 import health_check
 health_check.autodiscover()

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "Topic :: Utilities",
     ],
     install_requires=[
-        'Django>=1.2',
+        'Django>=1.6',
     ],
     include_package_data=True,
     zip_safe = False,


### PR DESCRIPTION
Django 1.6 has some non-backwards compatible moves, you might want to keep 2 different branches.
