### PR TITLE
Fix bad return of ServiceUnavailable exception

### DIFF
--- a/health_check_storage/base.py
+++ b/health_check_storage/base.py
@@ -52,4 +52,4 @@ class StorageHealthCheck(BaseHealthCheckBackend):
                 return ServiceUnavailable("File was not deleted")
             return True
         except Exception:
-            return ServiceUnavailable("Unknown exception")
+            raise ServiceUnavailable("Unknown exception")


### PR DESCRIPTION
The ServiceUnavailable exception in StorageHealthCheck was not raised correctly which resulted in `KeyError: ServiceUnavailable('Unknown exception',)` exception when DefaultFileStorageHealthCheck failed.
