### PR TITLE
fix: Update import for Celery app reference

### DIFF
--- a/health_check/contrib/celery_ping/backends.py
+++ b/health_check/contrib/celery_ping/backends.py
@@ -1,4 +1,4 @@
-from celery.app import default_app as app
+from celery import current_app as app
 from django.conf import settings
 
 from health_check.backends import BaseHealthCheckBackend


### PR DESCRIPTION
The `default_app` reference used in the Celery Ping healthcheck is `None` for me, leading to this error:

```bash
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/health_check/contrib/celery_ping/backends.py", line 15, in check_status
  ping_result = app.control.ping(timeout=timeout)
                        ^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/celery/local.py", line 143, in __getattr__
    return getattr(self._get_current_object(), name)
AttributeError: 'NoneType' object has no attribute 'control'
Internal Server Error: /healthcheck
```

When replacing the import of `default_app` with `current_app`, as shown in the [celery documentation](https://docs.celeryq.dev/en/v5.5.3/userguide/application.html#breaking-the-chain), the health check works for me.

I assume this was a breaking change introduced with Celery 5, but haven't verified this.

Since `current_app` defaults to `default_app` when `default_app` is not `None`, this change should not have a negative impact even for cases where default_app is not None. See  [this line](https://github.com/celery/celery/blob/95bec6d824363a6bb0ff08eda0da42e0d52c2a18/celery/_state.py#L92) in celery.