### PR TITLE
Fix missing URLs on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
   { name = "Kristian Ollegaard", email = "kristian@oellegaard.com" },
   { name = "Johannes Maron", email = "johannes@maron.family" }
 ]
-homepage = "https://github.com/revsys/django-health-check"
+urls = {Repository = "https://github.com/revsys/django-health-check", Documentation = "https://django-health-check.readthedocs.io"}
 keywords = ["django", "postgresql"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ authors = [
   { name = "Kristian Ollegaard", email = "kristian@oellegaard.com" },
   { name = "Johannes Maron", email = "johannes@maron.family" }
 ]
-urls = {Repository = "https://github.com/revsys/django-health-check", Documentation = "https://django-health-check.readthedocs.io"}
 keywords = ["django", "postgresql"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -41,6 +40,15 @@ dynamic = [
 dependencies = [
   "Django>=4.2",
 ]
+
+[project.urls]
+# https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels
+Homepage = "https://django-health-check.readthedocs.io/"
+Changelog = "https://github.com/revsys/django-health-check/releases"
+Source = "https://github.com/revsys/django-health-check"
+Releasenotes = "https://github.com/revsys/django-health-check/releases/latest"
+Documentation = "https://django-health-check.readthedocs.io/"
+Issues = "https://github.com/revsys/django-health-check/issues"
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
currently, there are no URLs to the repo/documentation on PyPI left column:
<img width="811" height="608" alt="image" src="https://github.com/user-attachments/assets/1a8e0a67-60aa-4292-8d7a-3562f4cb114c" />
