### PR TITLE
Remove duplicated pyupgrade setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,6 @@ repos:
       - id: end-of-file-fixer
       - id: no-commit-to-branch
         args: [--branch, main]
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
-    hooks:
-      - id: pyupgrade
   - repo: https://github.com/adamchainz/django-upgrade
     rev: 1.29.1
     hooks:


### PR DESCRIPTION
UP ruleset is already enabled in the ruff config, and ruff is called via hooks. The hook based setup for pyupgrade was redundant.