### PR TITLE
Adjust management command

### DIFF
--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -4,14 +4,50 @@ from io import StringIO
 from urllib.parse import urlparse
 
 import pytest
+import pytest_django.live_server_helper
 from django.core.management import call_command
 
 
 class TestHealthCheckCommand:
     """Test health_check management command."""
 
-    def test_handle__success(self, live_server):
+    @pytest.mark.django_db
+    def test_handle__success(self):
         """Return exit code 0 when all checks pass."""
+        stdout = StringIO()
+        stderr = StringIO()
+        call_command(
+            "health_check",
+            "health_check_test",
+            stdout=stdout,
+            stderr=stderr,
+        )
+        output = stdout.getvalue()
+        # Check that output contains health check results
+        assert "Database" in output and "Cache" in output
+        assert "OK" in output or "working" in output
+
+    def test_handle__error(self):
+        """Return exit code 1 when checks fail."""
+        stdout = StringIO()
+        stderr = StringIO()
+        with pytest.raises(SystemExit) as exc_info:
+            call_command(
+                "health_check",
+                "health_check_fail",
+                stdout=stdout,
+                stderr=stderr,
+            )
+        assert exc_info.value.code == 1
+        output = stdout.getvalue()
+        # Should display the error message from the failing check
+        assert "Test failure" in output and "AlwaysFailingCheck" in output
+
+    def test_handle__endpoint__success(
+        self,
+        live_server: pytest_django.live_server_helper.LiveServer,
+    ):
+        """Return exit code 0 when all checks pass when making http call."""
         parsed = urlparse(live_server.url)
         addrport = f"{parsed.hostname}:{parsed.port}"
 
@@ -21,15 +57,19 @@ class TestHealthCheckCommand:
             "health_check",
             "health_check_test",
             addrport,
+            "--make-http-request-directly",
             stdout=stdout,
             stderr=stderr,
         )
         output = stdout.getvalue()
         # Check that output contains health check results
-        assert "Database" in output or "Cache" in output
+        assert "Database" in output and "Cache" in output
         assert "OK" in output or "working" in output
 
-    def test_handle__http_error(self, live_server):
+    def test_handle__endpoint__http_error(
+        self,
+        live_server: pytest_django.live_server_helper.LiveServer,
+    ):
         """Return exit code 1 when checks fail with HTTP 500."""
         parsed = urlparse(live_server.url)
         addrport = f"{parsed.hostname}:{parsed.port}"
@@ -41,6 +81,7 @@ class TestHealthCheckCommand:
                 "health_check",
                 "health_check_fail",
                 addrport,
+                "--make-http-request-directly",
                 stdout=stdout,
                 stderr=stderr,
             )
@@ -49,7 +90,7 @@ class TestHealthCheckCommand:
         # Should display the error message from the failing check
         assert "Test failure" in output or "AlwaysFailingCheck" in output
 
-    def test_handle__url_error__connection_refused(self):
+    def test_handle__endpoint__url_error__connection_refused(self):
         """Return exit code 2 when URL cannot be reached (connection refused)."""
         stdout = StringIO()
         stderr = StringIO()
@@ -58,6 +99,7 @@ class TestHealthCheckCommand:
                 "health_check",
                 "health_check_test",
                 "localhost:9999",
+                "--make-http-request-directly",
                 stdout=stdout,
                 stderr=stderr,
             )

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -12,13 +12,14 @@ class TestHealthCheckCommand:
     """Test health_check management command."""
 
     @pytest.mark.django_db
-    def test_handle__success(self):
+    def test_handle__no_http__success(self):
         """Return exit code 0 when all checks pass."""
         stdout = StringIO()
         stderr = StringIO()
         call_command(
             "health_check",
             "health_check_test",
+            "--no-http",
             stdout=stdout,
             stderr=stderr,
         )
@@ -27,7 +28,7 @@ class TestHealthCheckCommand:
         assert "Database" in output and "Cache" in output
         assert "OK" in output or "working" in output
 
-    def test_handle__error(self):
+    def test_handle__no_http__error(self):
         """Return exit code 1 when checks fail."""
         stdout = StringIO()
         stderr = StringIO()
@@ -35,6 +36,7 @@ class TestHealthCheckCommand:
             call_command(
                 "health_check",
                 "health_check_fail",
+                "--no-http",
                 stdout=stdout,
                 stderr=stderr,
             )
@@ -57,7 +59,6 @@ class TestHealthCheckCommand:
             "health_check",
             "health_check_test",
             addrport,
-            "--make-http-request-directly",
             stdout=stdout,
             stderr=stderr,
         )
@@ -81,7 +82,6 @@ class TestHealthCheckCommand:
                 "health_check",
                 "health_check_fail",
                 addrport,
-                "--make-http-request-directly",
                 stdout=stdout,
                 stderr=stderr,
             )
@@ -99,7 +99,6 @@ class TestHealthCheckCommand:
                 "health_check",
                 "health_check_test",
                 "localhost:9999",
-                "--make-http-request-directly",
                 stdout=stdout,
                 stderr=stderr,
             )

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -29,7 +29,13 @@ urlpatterns = [
     # Failing endpoint for testing error handling
     path(
         "health/fail/",
-        HealthCheckView.as_view(checks=[AlwaysFailingCheck]),
+        HealthCheckView.as_view(
+            checks=[
+                AlwaysFailingCheck,
+                "health_check.checks.Database",
+                "health_check.checks.Cache",
+            ]
+        ),
         name="health_check_fail",
     ),
 ]


### PR DESCRIPTION
Make `health_check` management command be able to work without making actual HTTP requests.

Before, you could simply run `health_check` command without starting the server, which is more comfortable than keeping in mind that the server must be running. Also, it doesn't work via localhost in k8s pods(Maybe if I specify ip, it would work, but for that I need to specify a different ip for a different project, which is not handy).

So I adjusted the command so that by default it would simulate a request to view(Not calling it via HTTP), but keeping the ability to call it directly via HTTP.

Example of output:

<img width="929" height="325" alt="image" src="https://github.com/user-attachments/assets/f18a12c6-67ad-4ea9-8f2e-f6a878da3886" />
