### PR TITLE
Fix migration command in migration guide

### DIFF
--- a/docs/migrate-to-v4.md
+++ b/docs/migrate-to-v4.md
@@ -7,7 +7,7 @@
 1. If you have `health_check.db` in your `INSTALLED_APPS`, remove revert the migration to drop the `TestModel` table:
 
    ```shell
-   python manage.py migrate health_check.db zero
+   python manage.py migrate db zero
    ```
 
 1. Remove these `health_check.*` sub‑apps from `INSTALLED_APPS` but keep `health_check`!


### PR DESCRIPTION
Correct the migration command for health_check.db to db.

I've updated django-health-check from below 3.21 to 3.21+ twice today. Both time I've run into this error:
`CommandError: No installed app with label 'health_check.db'. Did you mean 'db'?`

Using `migrate db zero` worked in both cases.