### PR TITLE
Ref #519 -- Extend CLI HTTPS support and verbosity

### DIFF
--- a/docs/container.md
+++ b/docs/container.md
@@ -40,7 +40,7 @@ python manage.py health_check health_check-container localhost:8000 --forwarded-
 > [!IMPORTANT]
 > When using the `health_check` command, ensure that the host is included in your `ALLOWED_HOSTS` setting.
 > The command automatically uses the first entry from `ALLOWED_HOSTS` for the `X-Forwarded-Host` header if available.
-> For SSL-enabled applications, use the `--forwarded-proto https` flag.
+> The `X-Forwarded-Proto` header defaults to `https`; use `--forwarded-proto http` if your application doesn't use SSL.
 
 Your host name and port may vary depending on your container setup.
 
@@ -100,3 +100,6 @@ spec:
 > [!TIP]
 > Configure `X-Forwarded-Host` to match your domain from `ALLOWED_HOSTS` and set `X-Forwarded-Proto` to `https` if your application enforces SSL.
 > See Django's [USE_X_FORWARDED_HOST](https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-USE_X_FORWARDED_HOST) and [SECURE_PROXY_SSL_HEADER](https://docs.djangoproject.com/en/stable/ref/settings/#secure-proxy-ssl-header) settings.
+
+> [!NOTE]
+> When using `httpGet` probes in Kubernetes, ensure your WSGI or ASGI server binds to `0.0.0.0` (not just `127.0.0.1`) to be accessible to the kubelet making the health check requests.

--- a/health_check/management/commands/health_check.py
+++ b/health_check/management/commands/health_check.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
             nargs="?",
             type=str,
             default=self.default_addrport,
-            help=f"Optional port number, or ipaddr:port (default: :{self.default_addrport})",
+            help=f"Optional port number, or ipaddr:port (default: {self.default_addrport})",
         )
         parser.add_argument(
             "--forwarded-host",
@@ -99,7 +99,7 @@ class Command(BaseCommand):
                     sys.exit(1)
                 case 400:
                     self.stderr.write(
-                        f'"{url}" is not reachable: {e.reason}\nPlease check your ALLOWED_HOSTS setting or use the --forwarded-host option.'
+                        f"{url!r} is not reachable: {e.reason}\nPlease check your ALLOWED_HOSTS setting or use the --forwarded-host option."
                     )
                     sys.exit(2)
                 case _:
@@ -112,7 +112,7 @@ class Command(BaseCommand):
                     sys.exit(2)
         except urllib.error.URLError as e:
             self.stderr.write(
-                f'"{url}" is not reachable: {e.reason}\nPlease check your server is running and reachable.'
+                f"{url!r} is not reachable: {e.reason}\nPlease check your server is running and reachable."
             )
             sys.exit(2)
         except TimeoutError as e:

--- a/health_check/management/commands/health_check.py
+++ b/health_check/management/commands/health_check.py
@@ -1,13 +1,27 @@
+import os
 import sys
 import urllib.error
 import urllib.request
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
 
 
 class Command(BaseCommand):
     help = "Run health checks and exit 0 if everything went well."
+
+    @property
+    def default_forwarded_host(self):
+        return (
+            settings.ALLOWED_HOSTS[0].strip(".")
+            if settings.ALLOWED_HOSTS and settings.ALLOWED_HOSTS[0] != "*"
+            else None
+        )
+
+    @property
+    def default_addrport(self):
+        return ":".join([os.getenv("HOST", "127.0.0.1"), os.getenv("PORT", "8000")])
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -19,28 +33,90 @@ class Command(BaseCommand):
             "addrport",
             nargs="?",
             type=str,
-            help="Optional port number, or ipaddr:port (default: localhost:8000)",
-            default="localhost:8000",
+            default=self.default_addrport,
+            help=f"Optional port number, or ipaddr:port (default: :{self.default_addrport})",
+        )
+        parser.add_argument(
+            "--forwarded-host",
+            type=str,
+            default=self.default_forwarded_host,
+            help=f"Value for X-Forwarded-Host header (default: {self.default_forwarded_host})",
+        )
+        parser.add_argument(
+            "--forwarded-proto",
+            type=str,
+            choices=["http", "https"],
+            default="https",
+            help="Value for X-Forwarded-Proto header (default: https)",
+        )
+        parser.add_argument(
+            "--timeout",
+            type=int,
+            default=5,
+            help="Timeout in seconds for the health check request (default: 5 seconds)",
         )
 
     def handle(self, *args, **options):
         endpoint = options.get("endpoint")
-        path = reverse(endpoint)
-        host, sep, port = options.get("addrport").partition(":")
-        url = f"http://{host}:{port}{path}" if sep else f"http://{host}{path}"
-        request = urllib.request.Request(  # noqa: S310
-            url, headers={"Accept": "text/plain"}
-        )
         try:
-            response = urllib.request.urlopen(request)  # noqa: S310
+            path = reverse(endpoint)
+        except NoReverseMatch as e:
+            self.stderr.write(
+                f"Could not resolve endpoint {endpoint!r}: {e}\n"
+                "Please provide a valid URL pattern name for the health check endpoint."
+            )
+            sys.exit(2)
+        addrport = options.get("addrport")
+        proto = (
+            "https"
+            if settings.SECURE_SSL_REDIRECT and not settings.USE_X_FORWARDED_HOST
+            else "http"
+        )
+        url = f"{proto}://{addrport}{path}"
+
+        headers = {"Accept": "text/plain"}
+
+        # Add X-Forwarded-Host header
+        if forwarded_host := options.get("forwarded_host"):
+            headers["X-Forwarded-Host"] = forwarded_host
+
+        # Add X-Forwarded-Proto header
+        if forwarded_proto := options.get("forwarded_proto"):
+            headers["X-Forwarded-Proto"] = forwarded_proto
+
+        if options.get("verbosity", 1) >= 2:
+            self.stdout.write(
+                f"Checking health endpoint at {url!r} with headers: {headers}"
+            )
+
+        request = urllib.request.Request(url, headers=headers)  # noqa: S310
+        try:
+            response = urllib.request.urlopen(request, timeout=options["timeout"])  # noqa: S310
         except urllib.error.HTTPError as e:
-            # 500 status codes will raise HTTPError
-            self.stdout.write(e.read().decode("utf-8"))
-            sys.exit(1)
+            match e.code:
+                case 500:  # Health check failed
+                    self.stdout.write(e.read().decode("utf-8"))
+                    sys.exit(1)
+                case 400:
+                    self.stderr.write(
+                        f'"{url}" is not reachable: {e.reason}\nPlease check your ALLOWED_HOSTS setting or use the --forwarded-host option.'
+                    )
+                    sys.exit(2)
+                case _:
+                    self.stderr.write(
+                        "Unexpected HTTP error "
+                        f"when trying to reach {url!r}: {e}\n"
+                        f"You may have selected an invalid endpoint {endpoint!r}"
+                        f" or another application is running on {addrport!r}."
+                    )
+                    sys.exit(2)
         except urllib.error.URLError as e:
             self.stderr.write(
-                f'"{url}" is not reachable: {e.reason}\nPlease check your ALLOWED_HOSTS setting.'
+                f'"{url}" is not reachable: {e.reason}\nPlease check your server is running and reachable.'
             )
+            sys.exit(2)
+        except TimeoutError as e:
+            self.stderr.write(f"Timeout when trying to reach {url!r}: {e}")
             sys.exit(2)
         else:
             self.stdout.write(response.read().decode("utf-8"))

--- a/health_check/management/commands/health_check.py
+++ b/health_check/management/commands/health_check.py
@@ -67,10 +67,11 @@ class Command(BaseCommand):
             )
             sys.exit(2)
         addrport = options.get("addrport")
-        # Determine protocol for the health check URL:
-        # Use HTTPS only if SSL redirect is enabled AND forwarded headers are not used.
-        # In most containerized setups, the app listens on HTTP and relies on
-        # X-Forwarded-Proto header to indicate the original protocol.
+        # Determine the protocol to use when connecting to the local server:
+        # - Connect via HTTPS only if SSL redirect is enabled AND forwarded headers are not used
+        #   (meaning the app truly requires HTTPS connections)
+        # - Otherwise, connect via HTTP (typical for containerized apps where the app listens
+        #   on HTTP and X-Forwarded-Proto header indicates the original protocol to Django)
         proto = (
             "https"
             if settings.SECURE_SSL_REDIRECT and not settings.USE_X_FORWARDED_HOST

--- a/health_check/management/commands/health_check.py
+++ b/health_check/management/commands/health_check.py
@@ -67,11 +67,8 @@ class Command(BaseCommand):
             )
             sys.exit(2)
         addrport = options.get("addrport")
-        # Determine the protocol to use when connecting to the local server:
-        # - Connect via HTTPS only if SSL redirect is enabled AND forwarded headers are not used
-        #   (meaning the app truly requires HTTPS connections)
-        # - Otherwise, connect via HTTP (typical for containerized apps where the app listens
-        #   on HTTP and X-Forwarded-Proto header indicates the original protocol to Django)
+        # Use HTTPS only when SSL redirect is enabled without forwarded headers (direct HTTPS required).
+        # Otherwise use HTTP (typical for containers with X-Forwarded-Proto header support).
         proto = (
             "https"
             if settings.SECURE_SSL_REDIRECT and not settings.USE_X_FORWARDED_HOST

--- a/health_check/management/commands/health_check.py
+++ b/health_check/management/commands/health_check.py
@@ -67,6 +67,10 @@ class Command(BaseCommand):
             )
             sys.exit(2)
         addrport = options.get("addrport")
+        # Determine protocol for the health check URL:
+        # Use HTTPS only if SSL redirect is enabled AND forwarded headers are not used.
+        # In most containerized setups, the app listens on HTTP and relies on
+        # X-Forwarded-Proto header to indicate the original protocol.
         proto = (
             "https"
             if settings.SECURE_SSL_REDIRECT and not settings.USE_X_FORWARDED_HOST

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -64,3 +64,39 @@ class TestHealthCheckCommand:
         assert exc_info.value.code == 2
         error_output = stderr.getvalue()
         assert "not reachable" in error_output
+
+    def test_handle__forwarded_host(self, live_server):
+        """Set X-Forwarded-Host header when --forwarded-host is provided."""
+        parsed = urlparse(live_server.url)
+        addrport = f"{parsed.hostname}:{parsed.port}"
+
+        stdout = StringIO()
+        stderr = StringIO()
+        call_command(
+            "health_check",
+            "health_check_test",
+            addrport,
+            forwarded_host="example.com",
+            stdout=stdout,
+            stderr=stderr,
+        )
+        output = stdout.getvalue()
+        assert "OK" in output or "working" in output
+
+    def test_handle__forwarded_proto(self, live_server):
+        """Set X-Forwarded-Proto header when --forwarded-proto is provided."""
+        parsed = urlparse(live_server.url)
+        addrport = f"{parsed.hostname}:{parsed.port}"
+
+        stdout = StringIO()
+        stderr = StringIO()
+        call_command(
+            "health_check",
+            "health_check_test",
+            addrport,
+            forwarded_proto="https",
+            stdout=stdout,
+            stderr=stderr,
+        )
+        output = stdout.getvalue()
+        assert "OK" in output or "working" in output

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1,5 +1,6 @@
 """Tests for health_check management command."""
 
+import os
 from io import StringIO
 from unittest.mock import Mock, patch
 from urllib.error import HTTPError
@@ -133,7 +134,6 @@ class TestHealthCheckCommand:
                     headers = call_args.args[1] if len(call_args.args) > 1 else {}
                 assert headers.get("X-Forwarded-Proto") == "https"
                 # Verify command completed successfully
-                assert mock_urlopen.called
                 output = stdout.getvalue()
                 assert "OK" in output
 
@@ -286,9 +286,6 @@ class TestHealthCheckCommand:
 
     def test_handle__default_addrport_from_env(self, live_server):
         """Default addrport uses HOST and PORT environment variables."""
-        import os
-        from unittest.mock import patch
-
         parsed = urlparse(live_server.url)
 
         # Set environment variables

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1,6 +1,8 @@
 """Tests for health_check management command."""
 
 from io import StringIO
+from unittest.mock import Mock, patch
+from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 
 import pytest
@@ -100,3 +102,174 @@ class TestHealthCheckCommand:
         )
         output = stdout.getvalue()
         assert "OK" in output or "working" in output
+
+    def test_handle__default_forwarded_proto_is_https(self, live_server):
+        """X-Forwarded-Proto header defaults to 'https'."""
+        parsed = urlparse(live_server.url)
+        addrport = f"{parsed.hostname}:{parsed.port}"
+
+        stdout = StringIO()
+        stderr = StringIO()
+        
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_response = Mock()
+            mock_response.read.return_value = b"OK"
+            mock_urlopen.return_value = mock_response
+            
+            with patch("urllib.request.Request") as mock_request:
+                call_command(
+                    "health_check",
+                    "health_check_test",
+                    addrport,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+                # Verify that Request was called with X-Forwarded-Proto: https
+                call_args = mock_request.call_args
+                headers = call_args[1]["headers"] if len(call_args) > 1 else call_args.kwargs.get("headers", {})
+                assert headers.get("X-Forwarded-Proto") == "https"
+
+    def test_handle__verbosity_level_0(self, live_server):
+        """Verbosity level 0 shows minimal output."""
+        parsed = urlparse(live_server.url)
+        addrport = f"{parsed.hostname}:{parsed.port}"
+
+        stdout = StringIO()
+        stderr = StringIO()
+        call_command(
+            "health_check",
+            "health_check_test",
+            addrport,
+            verbosity=0,
+            stdout=stdout,
+            stderr=stderr,
+        )
+        output = stdout.getvalue()
+        # At verbosity 0, should still show results but no debug info
+        assert "Checking health endpoint" not in output
+
+    def test_handle__verbosity_level_2(self, live_server):
+        """Verbosity level 2 shows debug information."""
+        parsed = urlparse(live_server.url)
+        addrport = f"{parsed.hostname}:{parsed.port}"
+
+        stdout = StringIO()
+        stderr = StringIO()
+        call_command(
+            "health_check",
+            "health_check_test",
+            addrport,
+            verbosity=2,
+            stdout=stdout,
+            stderr=stderr,
+        )
+        output = stdout.getvalue()
+        # At verbosity 2, should show debug info about the request
+        assert "Checking health endpoint" in output
+        assert "with headers:" in output
+
+    def test_handle__http_400_error(self, live_server):
+        """Return exit code 2 and helpful message for HTTP 400 errors."""
+        parsed = urlparse(live_server.url)
+        addrport = f"{parsed.hostname}:{parsed.port}"
+
+        stdout = StringIO()
+        stderr = StringIO()
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = HTTPError(
+                url=f"http://{addrport}/health/test/",
+                code=400,
+                msg="Bad Request",
+                hdrs={},
+                fp=None,
+            )
+            
+            with pytest.raises(SystemExit) as exc_info:
+                call_command(
+                    "health_check",
+                    "health_check_test",
+                    addrport,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+            
+            assert exc_info.value.code == 2
+            error_output = stderr.getvalue()
+            assert "not reachable" in error_output
+            assert "ALLOWED_HOSTS" in error_output or "forwarded-host" in error_output
+
+    def test_handle__unexpected_http_error(self, live_server):
+        """Return exit code 2 and helpful message for unexpected HTTP errors."""
+        parsed = urlparse(live_server.url)
+        addrport = f"{parsed.hostname}:{parsed.port}"
+
+        stdout = StringIO()
+        stderr = StringIO()
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = HTTPError(
+                url=f"http://{addrport}/health/test/",
+                code=404,
+                msg="Not Found",
+                hdrs={},
+                fp=None,
+            )
+            
+            with pytest.raises(SystemExit) as exc_info:
+                call_command(
+                    "health_check",
+                    "health_check_test",
+                    addrport,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+            
+            assert exc_info.value.code == 2
+            error_output = stderr.getvalue()
+            assert "Unexpected HTTP error" in error_output
+            assert "invalid endpoint" in error_output
+
+    def test_handle__timeout_error(self, live_server):
+        """Return exit code 2 when request times out."""
+        parsed = urlparse(live_server.url)
+        addrport = f"{parsed.hostname}:{parsed.port}"
+
+        stdout = StringIO()
+        stderr = StringIO()
+
+        with patch("urllib.request.urlopen") as mock_urlopen:
+            mock_urlopen.side_effect = TimeoutError("Connection timed out")
+            
+            with pytest.raises(SystemExit) as exc_info:
+                call_command(
+                    "health_check",
+                    "health_check_test",
+                    addrport,
+                    timeout=1,
+                    stdout=stdout,
+                    stderr=stderr,
+                )
+            
+            assert exc_info.value.code == 2
+            error_output = stderr.getvalue()
+            assert "Timeout" in error_output
+
+    def test_handle__invalid_endpoint(self):
+        """Return exit code 2 when endpoint name is invalid."""
+        stdout = StringIO()
+        stderr = StringIO()
+
+        with pytest.raises(SystemExit) as exc_info:
+            call_command(
+                "health_check",
+                "nonexistent_endpoint",
+                "localhost:8000",
+                stdout=stdout,
+                stderr=stderr,
+            )
+        
+        assert exc_info.value.code == 2
+        error_output = stderr.getvalue()
+        assert "Could not resolve endpoint" in error_output
+        assert "nonexistent_endpoint" in error_output

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -2,7 +2,7 @@
 
 from io import StringIO
 from unittest.mock import Mock, patch
-from urllib.error import HTTPError, URLError
+from urllib.error import HTTPError
 from urllib.parse import urlparse
 
 import pytest
@@ -110,12 +110,12 @@ class TestHealthCheckCommand:
 
         stdout = StringIO()
         stderr = StringIO()
-        
+
         with patch("urllib.request.urlopen") as mock_urlopen:
             mock_response = Mock()
             mock_response.read.return_value = b"OK"
             mock_urlopen.return_value = mock_response
-            
+
             with patch("urllib.request.Request") as mock_request:
                 call_command(
                     "health_check",
@@ -184,7 +184,7 @@ class TestHealthCheckCommand:
                 hdrs={},
                 fp=None,
             )
-            
+
             with pytest.raises(SystemExit) as exc_info:
                 call_command(
                     "health_check",
@@ -193,7 +193,7 @@ class TestHealthCheckCommand:
                     stdout=stdout,
                     stderr=stderr,
                 )
-            
+
             assert exc_info.value.code == 2
             error_output = stderr.getvalue()
             assert "not reachable" in error_output
@@ -215,7 +215,7 @@ class TestHealthCheckCommand:
                 hdrs={},
                 fp=None,
             )
-            
+
             with pytest.raises(SystemExit) as exc_info:
                 call_command(
                     "health_check",
@@ -224,7 +224,7 @@ class TestHealthCheckCommand:
                     stdout=stdout,
                     stderr=stderr,
                 )
-            
+
             assert exc_info.value.code == 2
             error_output = stderr.getvalue()
             assert "Unexpected HTTP error" in error_output
@@ -240,7 +240,7 @@ class TestHealthCheckCommand:
 
         with patch("urllib.request.urlopen") as mock_urlopen:
             mock_urlopen.side_effect = TimeoutError("Connection timed out")
-            
+
             with pytest.raises(SystemExit) as exc_info:
                 call_command(
                     "health_check",
@@ -250,7 +250,7 @@ class TestHealthCheckCommand:
                     stdout=stdout,
                     stderr=stderr,
                 )
-            
+
             assert exc_info.value.code == 2
             error_output = stderr.getvalue()
             assert "Timeout" in error_output
@@ -268,7 +268,7 @@ class TestHealthCheckCommand:
                 stdout=stdout,
                 stderr=stderr,
             )
-        
+
         assert exc_info.value.code == 2
         error_output = stderr.getvalue()
         assert "Could not resolve endpoint" in error_output


### PR DESCRIPTION
* Enable default support for X-forwarded headers to handle HTTPS redirects.
* Add more error handling to descritive outputs to support user debugging effors.
