### PR TITLE
Fix #606 -- Assign unique cache key to avoid race conditions

### DIFF
--- a/health_check/checks.py
+++ b/health_check/checks.py
@@ -8,7 +8,6 @@ import pathlib
 import smtplib
 import socket
 import uuid
-import warnings
 
 import dns.asyncresolver
 import psutil
@@ -57,7 +56,6 @@ class Cache(HealthCheck):
         alias: The cache alias to test against.
         key_prefix: Prefix for the cache key to use for the test.
         timeout: Time until probe keys expire in the cache backend.
-        cache_key: Deprecated alias for key_prefix.
 
     """
 
@@ -66,24 +64,6 @@ class Cache(HealthCheck):
     timeout: datetime.timedelta = dataclasses.field(
         default=datetime.timedelta(seconds=5), repr=False
     )
-    cache_key: str | None = dataclasses.field(default=None, repr=False)
-
-    def __post_init__(self):
-        """Support the deprecated `cache_key` argument."""
-        if self.cache_key is None:
-            return
-        warnings.warn(
-            "`Cache.cache_key` is deprecated and will be removed in a future release. "
-            "Use `Cache.key_prefix` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if (
-            self.key_prefix != "djangohealthcheck_test"
-            and self.key_prefix != self.cache_key
-        ):
-            raise ValueError("Provide either `key_prefix` or `cache_key`, not both.")
-        self.key_prefix = self.cache_key
 
     async def run(self):
         cache = caches[self.alias]

--- a/health_check/checks.py
+++ b/health_check/checks.py
@@ -54,7 +54,7 @@ class Cache(HealthCheck):
 
     Args:
         alias: The cache alias to test against.
-        key_prefix: Prefix for the cache key to use for the test.
+        key_prefix: Prefix for the node specific cache key.
         timeout: Time until probe keys expire in the cache backend.
 
     """
@@ -67,10 +67,9 @@ class Cache(HealthCheck):
 
     async def run(self):
         cache = caches[self.alias]
-        ts = datetime.datetime.now().timestamp()
         # Use an isolated key per probe run to avoid cross-process write races.
         cache_key = f"{self.key_prefix}:{uuid.uuid4().hex}"
-        cache_value = f"itworks-{ts}"
+        cache_value = f"itworks-{datetime.datetime.now().timestamp()}"
         try:
             await cache.aset(
                 cache_key,

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -86,6 +86,29 @@ class TestCache:
             cache_key = mock_cache.aset.await_args.args[0]
             assert cache_key.startswith("healthcheck:")
 
+    @pytest.mark.asyncio
+    async def test_run_check__cache_generates_distinct_key_per_run(self):
+        """Cache check generates a new key on each probe run."""
+        with mock.patch("health_check.checks.caches") as mock_caches:
+            mock_cache = mock.MagicMock()
+            mock_caches.__getitem__.return_value = mock_cache
+            mock_cache.aset = mock.AsyncMock(return_value=None)
+
+            async def _aget(_key):
+                return mock_cache.aset.await_args.args[1]
+
+            mock_cache.aget = mock.AsyncMock(side_effect=_aget)
+
+            check = Cache()
+            first_result = await check.get_result()
+            second_result = await check.get_result()
+
+            assert first_result.error is None
+            assert second_result.error is None
+            first_key = mock_cache.aset.await_args_list[0].args[0]
+            second_key = mock_cache.aset.await_args_list[1].args[0]
+            assert first_key != second_key
+
 
 class TestDatabase:
     """Test the Database health check."""

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -68,8 +68,8 @@ class TestCache:
             assert mock_cache.aset.await_args.kwargs["timeout"] == 2.0
 
     @pytest.mark.asyncio
-    async def test_run_check__cache_supports_deprecated_cache_key_argument(self):
-        """Cache check supports deprecated `cache_key` argument."""
+    async def test_run_check__cache_supports_key_prefix_argument(self):
+        """Cache check supports custom key prefix argument."""
         with mock.patch("health_check.checks.caches") as mock_caches:
             mock_cache = mock.MagicMock()
             mock_caches.__getitem__.return_value = mock_cache
@@ -80,16 +80,11 @@ class TestCache:
 
             mock_cache.aget = mock.AsyncMock(side_effect=_aget)
 
-            with pytest.warns(
-                DeprecationWarning,
-                match="Cache.cache_key.*deprecated",
-            ):
-                check = Cache(cache_key="legacy_prefix")
-
+            check = Cache(key_prefix="healthcheck")
             result = await check.get_result()
             assert result.error is None
             cache_key = mock_cache.aset.await_args.args[0]
-            assert cache_key.startswith("legacy_prefix:")
+            assert cache_key.startswith("healthcheck:")
 
 
 class TestDatabase:


### PR DESCRIPTION
Fixes https://github.com/codingjoe/django-health-check/issues/606

`Cache.run()` was using a shared key (`djangohealthcheck_test`) with a per-request value (`itworks-{timestamp}`).
In multi-worker / multi-instance deployments, concurrent probes can overwrite each other between `set` and `get`, producing false negatives:

`ServiceUnavailable: Cache key djangohealthcheck_test does not match`

This PR switches the cache check to an isolated runtime key per probe (`<cache_key>:<uuid4>`), which removes cross-request/key collision races.

A configurable `timeout` with default of 5 seconds on probe keys.  
Reason: with per-probe keys, TTL guarantees automatic cleanup if a process crashes or the check exits before explicit delete, preventing temporary health-check keys from accumulating in shared cache backends.
