### PR TITLE
Make psutil an optional dependency

### DIFF
--- a/health_check/checks.py
+++ b/health_check/checks.py
@@ -40,6 +40,7 @@ except ModuleNotFoundError:
     class RedisError(Exception):
         pass
 
+
 try:
     import psutil
 except ModuleNotFoundError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,11 @@ dynamic = [
 dependencies = [
   "Django>=5.2",
   "dnspython>=2.0.0",
-  "psutil",
 ]
 
 [project.optional-dependencies]
 celery = ["celery>=5.0.0"]
+psutil = ["psutil"]
 kafka = ["confluent-kafka>=2.0.0"]
 rabbitmq = ["aio-pika>=9.0.0"]
 redis = ["redis>=4.2.0"]
@@ -72,6 +72,7 @@ test = [
   "pytest-django",
   "django-storages",
   "boto3",
+  "psutil",
 ]
 docs = [
   "mkdocs",

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -414,6 +414,16 @@ class TestDiskExceptionHandling:
             assert result.error is not None
             assert isinstance(result.error, ServiceReturnedUnexpectedResult)
 
+    @pytest.mark.asyncio
+    async def test_check_status__psutil_not_installed(self):
+        """Raise ServiceUnavailable when psutil is not installed."""
+        with mock.patch("health_check.checks.psutil", None):
+            check = Disk()
+            result = await check.get_result()
+            assert result.error is not None
+            assert isinstance(result.error, ServiceUnavailable)
+            assert "psutil is not installed" in str(result.error)
+
 
 class TestMailExceptionHandling:
     """Test Mail exception handling for uncovered code paths."""
@@ -539,6 +549,16 @@ class TestMemoryExceptionHandling:
             result = await check.get_result()
             assert result.error is not None
             assert isinstance(result.error, ServiceReturnedUnexpectedResult)
+
+    @pytest.mark.asyncio
+    async def test_check_status__psutil_not_installed(self):
+        """Raise ServiceUnavailable when psutil is not installed."""
+        with mock.patch("health_check.checks.psutil", None):
+            check = Memory()
+            result = await check.get_result()
+            assert result.error is not None
+            assert isinstance(result.error, ServiceUnavailable)
+            assert "psutil is not installed" in str(result.error)
 
 
 class TestStorageExceptionHandling:


### PR DESCRIPTION
Users who only need database, cache, or other checks no longer have to install psutil. Disk and Memory checks now raise ServiceUnavailable with a clear install instruction when psutil is missing.

Closes #613 