### PR TITLE
Fix #643 -- Add client_fractory to Redis check

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -51,7 +51,11 @@ urlpatterns = [
                 ),
                 (
                     "health_check.contrib.redis.Redis",
-                    {"client": RedisClient.from_url("redis://localhost:6379")},
+                    {
+                        "client_factory": lambda: RedisClient.from_url(
+                            "redis://localhost:6379"
+                        )
+                    },
                 ),
                 # AWS service status check
                 (

--- a/health_check/contrib/redis.py
+++ b/health_check/contrib/redis.py
@@ -46,7 +46,9 @@ class Redis(HealthCheck):
 
     """
 
-    client: RedisClient | RedisCluster | None = dataclasses.field(repr=False)
+    client: RedisClient | RedisCluster | None = dataclasses.field(
+        repr=False, default=None
+    )
     client_factory: typing.Callable[[], RedisClient | RedisCluster] | None = (
         dataclasses.field(repr=False, default=None)
     )

--- a/health_check/contrib/redis.py
+++ b/health_check/contrib/redis.py
@@ -64,13 +64,13 @@ class Redis(HealthCheck):
 
     async def run(self):
         logger.debug("Pinging Redis client...")
-        
+
         # Create a fresh client if using factory, otherwise use the provided client
         if self.client_factory:
             client = self.client_factory()
         else:
             client = self.client
-        
+
         try:
             await client.ping()
         except ConnectionRefusedError as e:

--- a/health_check/contrib/redis.py
+++ b/health_check/contrib/redis.py
@@ -53,9 +53,9 @@ class Redis(HealthCheck):
         dataclasses.field(repr=False, default=None)
     )
 
-    def __post_init__(self):
+    async def run(self):
         if self.client_factory:
-            self.client = self.client_factory()
+            client = self.client_factory()
         else:
             warnings.warn(
                 "The `client` argument is deprecated and will be removed in a future version. "
@@ -63,11 +63,10 @@ class Redis(HealthCheck):
                 DeprecationWarning,
                 stacklevel=2,
             )
-
-    async def run(self):
+            client = self.client
         logger.debug("Pinging Redis client...")
         try:
-            await self.client.ping()
+            await client.ping()
         except ConnectionRefusedError as e:
             raise ServiceUnavailable(
                 "Unable to connect to Redis: Connection was refused."
@@ -81,4 +80,4 @@ class Redis(HealthCheck):
         else:
             logger.debug("Connection established. Redis is healthy.")
         finally:
-            await self.client.aclose()
+            await client.aclose()

--- a/health_check/contrib/redis.py
+++ b/health_check/contrib/redis.py
@@ -46,15 +46,15 @@ class Redis(HealthCheck):
 
     """
 
-    client: RedisClient | RedisCluster | None = dataclasses.field(repr=False, default=None)
+    client: RedisClient | RedisCluster | None = dataclasses.field(repr=False)
     client_factory: typing.Callable[[], RedisClient | RedisCluster] | None = (
         dataclasses.field(repr=False, default=None)
     )
 
     def __post_init__(self):
-        if not self.client_factory and not self.client:
-            raise ValueError("Either 'client_factory' or 'client' must be provided.")
-        if self.client and not self.client_factory:
+        if self.client_factory:
+            self.client = self.client_factory()
+        else:
             warnings.warn(
                 "The `client` argument is deprecated and will be removed in a future version. "
                 "Please use `client_factory` instead.",
@@ -64,15 +64,8 @@ class Redis(HealthCheck):
 
     async def run(self):
         logger.debug("Pinging Redis client...")
-
-        # Create a fresh client if using factory, otherwise use the provided client
-        if self.client_factory:
-            client = self.client_factory()
-        else:
-            client = self.client
-
         try:
-            await client.ping()
+            await self.client.ping()
         except ConnectionRefusedError as e:
             raise ServiceUnavailable(
                 "Unable to connect to Redis: Connection was refused."
@@ -86,6 +79,4 @@ class Redis(HealthCheck):
         else:
             logger.debug("Connection established. Redis is healthy.")
         finally:
-            # Only close client if created by factory
-            if self.client_factory:
-                await client.aclose()
+            await self.client.aclose()

--- a/tests/contrib/test_redis.py
+++ b/tests/contrib/test_redis.py
@@ -23,7 +23,7 @@ class TestRedis:
         mock_client = mock.AsyncMock()
         mock_client.ping.return_value = True
 
-        check = RedisHealthCheck(client=None, client_factory=lambda: mock_client)
+        check = RedisHealthCheck(client_factory=lambda: mock_client)
         result = await check.get_result()
         assert result.error is None
         mock_client.ping.assert_called_once()
@@ -35,7 +35,7 @@ class TestRedis:
         mock_client = mock.AsyncMock()
         mock_client.ping.side_effect = ConnectionRefusedError("refused")
 
-        check = RedisHealthCheck(client=None, client_factory=lambda: mock_client)
+        check = RedisHealthCheck(client_factory=lambda: mock_client)
         result = await check.get_result()
         assert result.error is not None
         assert isinstance(result.error, ServiceUnavailable)
@@ -47,7 +47,7 @@ class TestRedis:
         mock_client = mock.AsyncMock()
         mock_client.ping.side_effect = RedisTimeoutError("timeout")
 
-        check = RedisHealthCheck(client=None, client_factory=lambda: mock_client)
+        check = RedisHealthCheck(client_factory=lambda: mock_client)
         result = await check.get_result()
         assert result.error is not None
         assert isinstance(result.error, ServiceUnavailable)
@@ -59,7 +59,7 @@ class TestRedis:
         mock_client = mock.AsyncMock()
         mock_client.ping.side_effect = RedisConnectionError("connection error")
 
-        check = RedisHealthCheck(client=None, client_factory=lambda: mock_client)
+        check = RedisHealthCheck(client_factory=lambda: mock_client)
         result = await check.get_result()
         assert result.error is not None
         assert isinstance(result.error, ServiceUnavailable)
@@ -93,7 +93,7 @@ class TestRedis:
             client.ping.return_value = True
             return client
 
-        check = RedisHealthCheck(client=None, client_factory=factory)
+        check = RedisHealthCheck(client_factory=factory)
         assert call_count == 1, "Factory should be called once during initialization"
 
         # Multiple requests reuse the same client
@@ -131,9 +131,7 @@ class TestRedis:
 
         from redis.asyncio import Redis as RedisClient
 
-        check = RedisHealthCheck(
-            client=None, client_factory=lambda: RedisClient.from_url(redis_url)
-        )
+        check = RedisHealthCheck(client_factory=lambda: RedisClient.from_url(redis_url))
         result = await check.get_result()
         assert result.error is None
 
@@ -162,6 +160,6 @@ class TestRedis:
             sentinel = Sentinel(sentinels)
             return sentinel.master_for(service_name)
 
-        check = RedisHealthCheck(client=None, client_factory=factory)
+        check = RedisHealthCheck(client_factory=factory)
         result = await check.get_result()
         assert result.error is None

--- a/tests/contrib/test_redis.py
+++ b/tests/contrib/test_redis.py
@@ -19,14 +19,15 @@ class TestRedis:
 
     @pytest.mark.asyncio
     async def test_redis__ok(self):
-        """Ping Redis successfully when using client parameter."""
+        """Ping Redis successfully when using client_factory parameter."""
         mock_client = mock.AsyncMock()
         mock_client.ping.return_value = True
 
-        check = RedisHealthCheck(client=mock_client)
+        check = RedisHealthCheck(client_factory=lambda: mock_client)
         result = await check.get_result()
         assert result.error is None
         mock_client.ping.assert_called_once()
+        mock_client.aclose.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_redis__connection_refused(self):
@@ -34,10 +35,11 @@ class TestRedis:
         mock_client = mock.AsyncMock()
         mock_client.ping.side_effect = ConnectionRefusedError("refused")
 
-        check = RedisHealthCheck(client=mock_client)
+        check = RedisHealthCheck(client_factory=lambda: mock_client)
         result = await check.get_result()
         assert result.error is not None
         assert isinstance(result.error, ServiceUnavailable)
+        mock_client.aclose.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_redis__timeout(self):
@@ -45,10 +47,11 @@ class TestRedis:
         mock_client = mock.AsyncMock()
         mock_client.ping.side_effect = RedisTimeoutError("timeout")
 
-        check = RedisHealthCheck(client=mock_client)
+        check = RedisHealthCheck(client_factory=lambda: mock_client)
         result = await check.get_result()
         assert result.error is not None
         assert isinstance(result.error, ServiceUnavailable)
+        mock_client.aclose.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_redis__connection_error(self):
@@ -56,10 +59,78 @@ class TestRedis:
         mock_client = mock.AsyncMock()
         mock_client.ping.side_effect = RedisConnectionError("connection error")
 
-        check = RedisHealthCheck(client=mock_client)
+        check = RedisHealthCheck(client_factory=lambda: mock_client)
         result = await check.get_result()
         assert result.error is not None
         assert isinstance(result.error, ServiceUnavailable)
+        mock_client.aclose.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_redis__client_deprecated(self):
+        """Verify DeprecationWarning is raised when using client parameter."""
+        mock_client = mock.AsyncMock()
+        mock_client.ping.return_value = True
+
+        with pytest.warns(DeprecationWarning, match="client.*deprecated.*client_factory"):
+            check = RedisHealthCheck(client=mock_client)
+
+        result = await check.get_result()
+        assert result.error is None
+        mock_client.ping.assert_called_once()
+        mock_client.aclose.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_redis__factory_creates_new_client_per_request(self):
+        """Verify client_factory creates a new client instance per request."""
+        call_count = 0
+        clients = []
+
+        def factory():
+            nonlocal call_count
+            call_count += 1
+            client = mock.AsyncMock()
+            client.ping.return_value = True
+            clients.append(client)
+            return client
+
+        check = RedisHealthCheck(client_factory=factory)
+
+        # First request
+        result1 = await check.get_result()
+        assert result1.error is None
+        assert call_count == 1, "Factory should be called once for first request"
+        assert len(clients) == 1
+        clients[0].ping.assert_called_once()
+        clients[0].aclose.assert_called_once()
+
+        # Second request
+        result2 = await check.get_result()
+        assert result2.error is None
+        assert call_count == 2, "Factory should be called again for second request"
+        assert len(clients) == 2
+        assert clients[0] is not clients[1], "Each request should get a new client"
+        clients[1].ping.assert_called_once()
+        clients[1].aclose.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_redis__client_not_closed_when_provided_directly(self):
+        """Verify user-provided client is not closed by health check."""
+        mock_client = mock.AsyncMock()
+        mock_client.ping.return_value = True
+
+        with pytest.warns(DeprecationWarning):
+            check = RedisHealthCheck(client=mock_client)
+
+        result = await check.get_result()
+        assert result.error is None
+        mock_client.ping.assert_called_once()
+        mock_client.aclose.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_redis__requires_client_or_factory(self):
+        """Verify ValueError is raised when neither client nor factory is provided."""
+        with pytest.raises(ValueError, match="Either 'client_factory' or 'client' must be provided"):
+            RedisHealthCheck()
 
     @pytest.mark.integration
     @pytest.mark.asyncio
@@ -71,11 +142,11 @@ class TestRedis:
 
         from redis.asyncio import Redis as RedisClient
 
-        client = RedisClient.from_url(redis_url)
-        check = RedisHealthCheck(client=client)
+        check = RedisHealthCheck(
+            client_factory=lambda: RedisClient.from_url(redis_url)
+        )
         result = await check.get_result()
         assert result.error is None
-        await client.aclose()
 
     @pytest.mark.integration
     @pytest.mark.asyncio
@@ -97,11 +168,11 @@ class TestRedis:
             host, port = node.strip().split(":")
             sentinels.append((host, int(port)))
 
-        # Create Sentinel and get master client
-        sentinel = Sentinel(sentinels)
-        master = sentinel.master_for(service_name)
+        # Create factory that returns Sentinel master client
+        def factory():
+            sentinel = Sentinel(sentinels)
+            return sentinel.master_for(service_name)
 
-        # Use the unified Redis check with the master client
-        check = RedisHealthCheck(client=master)
+        check = RedisHealthCheck(client_factory=factory)
         result = await check.get_result()
         assert result.error is None

--- a/tests/contrib/test_redis.py
+++ b/tests/contrib/test_redis.py
@@ -71,7 +71,9 @@ class TestRedis:
         mock_client = mock.AsyncMock()
         mock_client.ping.return_value = True
 
-        with pytest.warns(DeprecationWarning, match="client.*deprecated.*client_factory"):
+        with pytest.warns(
+            DeprecationWarning, match="client.*deprecated.*client_factory"
+        ):
             check = RedisHealthCheck(client=mock_client)
 
         result = await check.get_result()
@@ -97,7 +99,9 @@ class TestRedis:
         # Multiple requests reuse the same client
         result1 = await check.get_result()
         assert result1.error is None
-        assert call_count == 1, "Factory should not be called again for subsequent requests"
+        assert call_count == 1, (
+            "Factory should not be called again for subsequent requests"
+        )
 
         result2 = await check.get_result()
         assert result2.error is None

--- a/tests/contrib/test_redis.py
+++ b/tests/contrib/test_redis.py
@@ -23,7 +23,7 @@ class TestRedis:
         mock_client = mock.AsyncMock()
         mock_client.ping.return_value = True
 
-        check = RedisHealthCheck(client_factory=lambda: mock_client)
+        check = RedisHealthCheck(client=None, client_factory=lambda: mock_client)
         result = await check.get_result()
         assert result.error is None
         mock_client.ping.assert_called_once()
@@ -35,7 +35,7 @@ class TestRedis:
         mock_client = mock.AsyncMock()
         mock_client.ping.side_effect = ConnectionRefusedError("refused")
 
-        check = RedisHealthCheck(client_factory=lambda: mock_client)
+        check = RedisHealthCheck(client=None, client_factory=lambda: mock_client)
         result = await check.get_result()
         assert result.error is not None
         assert isinstance(result.error, ServiceUnavailable)
@@ -47,7 +47,7 @@ class TestRedis:
         mock_client = mock.AsyncMock()
         mock_client.ping.side_effect = RedisTimeoutError("timeout")
 
-        check = RedisHealthCheck(client_factory=lambda: mock_client)
+        check = RedisHealthCheck(client=None, client_factory=lambda: mock_client)
         result = await check.get_result()
         assert result.error is not None
         assert isinstance(result.error, ServiceUnavailable)
@@ -59,7 +59,7 @@ class TestRedis:
         mock_client = mock.AsyncMock()
         mock_client.ping.side_effect = RedisConnectionError("connection error")
 
-        check = RedisHealthCheck(client_factory=lambda: mock_client)
+        check = RedisHealthCheck(client=None, client_factory=lambda: mock_client)
         result = await check.get_result()
         assert result.error is not None
         assert isinstance(result.error, ServiceUnavailable)
@@ -77,44 +77,35 @@ class TestRedis:
         result = await check.get_result()
         assert result.error is None
         mock_client.ping.assert_called_once()
-        mock_client.aclose.assert_not_called()
+        mock_client.aclose.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_redis__factory_creates_new_client_per_request(self):
-        """Verify client_factory creates a new client instance per request."""
+    async def test_redis__factory_called_once_in_init(self):
+        """Verify client_factory is called once during initialization."""
         call_count = 0
-        clients = []
 
         def factory():
             nonlocal call_count
             call_count += 1
             client = mock.AsyncMock()
             client.ping.return_value = True
-            clients.append(client)
             return client
 
-        check = RedisHealthCheck(client_factory=factory)
+        check = RedisHealthCheck(client=None, client_factory=factory)
+        assert call_count == 1, "Factory should be called once during initialization"
 
-        # First request
+        # Multiple requests reuse the same client
         result1 = await check.get_result()
         assert result1.error is None
-        assert call_count == 1, "Factory should be called exactly once for the first request"
-        assert len(clients) == 1
-        clients[0].ping.assert_called_once()
-        clients[0].aclose.assert_called_once()
+        assert call_count == 1, "Factory should not be called again for subsequent requests"
 
-        # Second request
         result2 = await check.get_result()
         assert result2.error is None
-        assert call_count == 2, "Factory should be called exactly twice after two requests"
-        assert len(clients) == 2
-        assert clients[0] is not clients[1], "Each request should get a new client"
-        clients[1].ping.assert_called_once()
-        clients[1].aclose.assert_called_once()
+        assert call_count == 1, "Factory should still not be called again"
 
     @pytest.mark.asyncio
-    async def test_redis__client_not_closed_when_provided_directly(self):
-        """Verify user-provided client is not closed by health check."""
+    async def test_redis__client_always_closed(self):
+        """Verify client is always closed after health check."""
         mock_client = mock.AsyncMock()
         mock_client.ping.return_value = True
 
@@ -124,13 +115,7 @@ class TestRedis:
         result = await check.get_result()
         assert result.error is None
         mock_client.ping.assert_called_once()
-        mock_client.aclose.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_redis__requires_client_or_factory(self):
-        """Verify ValueError is raised when neither client nor factory is provided."""
-        with pytest.raises(ValueError, match="Either 'client_factory' or 'client' must be provided"):
-            RedisHealthCheck()
+        mock_client.aclose.assert_called_once()
 
     @pytest.mark.integration
     @pytest.mark.asyncio
@@ -143,7 +128,7 @@ class TestRedis:
         from redis.asyncio import Redis as RedisClient
 
         check = RedisHealthCheck(
-            client_factory=lambda: RedisClient.from_url(redis_url)
+            client=None, client_factory=lambda: RedisClient.from_url(redis_url)
         )
         result = await check.get_result()
         assert result.error is None
@@ -173,6 +158,6 @@ class TestRedis:
             sentinel = Sentinel(sentinels)
             return sentinel.master_for(service_name)
 
-        check = RedisHealthCheck(client_factory=factory)
+        check = RedisHealthCheck(client=None, client_factory=factory)
         result = await check.get_result()
         assert result.error is None

--- a/tests/contrib/test_redis.py
+++ b/tests/contrib/test_redis.py
@@ -98,7 +98,7 @@ class TestRedis:
         # First request
         result1 = await check.get_result()
         assert result1.error is None
-        assert call_count == 1, "Factory should be called once for first request"
+        assert call_count == 1, "Factory should be called exactly once for the first request"
         assert len(clients) == 1
         clients[0].ping.assert_called_once()
         clients[0].aclose.assert_called_once()
@@ -106,7 +106,7 @@ class TestRedis:
         # Second request
         result2 = await check.get_result()
         assert result2.error is None
-        assert call_count == 2, "Factory should be called again for second request"
+        assert call_count == 2, "Factory should be called exactly twice after two requests"
         assert len(clients) == 2
         assert clients[0] is not clients[1], "Each request should get a new client"
         clients[1].ping.assert_called_once()


### PR DESCRIPTION
Redis clients may leak connections between concurrent requests.
To prevent this we need to instanciate a client per request.
