### PR TITLE
Add "custom_task_queue_names" to Celery Ping check

### DIFF
--- a/health_check/contrib/celery.py
+++ b/health_check/contrib/celery.py
@@ -28,7 +28,9 @@ class Ping(HealthCheck):
 
     CORRECT_PING_RESPONSE: typing.ClassVar[dict[str, str]] = {"ok": "pong"}
     app: celery.Celery = dataclasses.field(default_factory=app_or_default)
-    custom_task_queue_names: set[str] | None = dataclasses.field(default=None, repr=False)
+    custom_task_queue_names: set[str] | None = dataclasses.field(
+        default=None, repr=False
+    )
     timeout: datetime.timedelta = dataclasses.field(
         default=datetime.timedelta(seconds=1), repr=False
     )


### PR DESCRIPTION
This way users can specify a custom set of queue names which should be checked.

As the Celery documentation recommends, most users probably don't use `app.conf.task_queues` as it is rather complicated and probably not what most users need.

To be able to still check existing queues and not only the default one, it would be very convenient to pass a set of queue names to be checked.

I'm aware of #428 but with the new checks structure it is very easy to add.

What do you think?