### PR TITLE
Fix #699 -- Gracefully handle None value from active_queues in Celery

### DIFF
--- a/health_check/contrib/celery.py
+++ b/health_check/contrib/celery.py
@@ -64,11 +64,14 @@ class Ping(HealthCheck):
         except TypeError:
             # conf.task_queues may be None
             defined_queues = {self.app.conf.task_default_queue}
+        inspect_result = self.app.control.inspect(active_workers)
+        active_queues_by_worker = inspect_result.active_queues() if inspect_result else None
+        if not active_queues_by_worker:
+            active_queues_by_worker = {}
+
         active_queues = {
             queue.get("name")
-            for queues in self.app.control.inspect(active_workers)
-            .active_queues()
-            .values()
+            for queues in active_queues_by_worker.values()
             for queue in queues
         }
 

--- a/health_check/contrib/celery.py
+++ b/health_check/contrib/celery.py
@@ -65,7 +65,9 @@ class Ping(HealthCheck):
             # conf.task_queues may be None
             defined_queues = {self.app.conf.task_default_queue}
         inspect_result = self.app.control.inspect(active_workers)
-        active_queues_by_worker = inspect_result.active_queues() if inspect_result else None
+        active_queues_by_worker = (
+            inspect_result.active_queues() if inspect_result else None
+        )
         if not active_queues_by_worker:
             active_queues_by_worker = {}
 

--- a/health_check/contrib/celery.py
+++ b/health_check/contrib/celery.py
@@ -64,16 +64,11 @@ class Ping(HealthCheck):
         except TypeError:
             # conf.task_queues may be None
             defined_queues = {self.app.conf.task_default_queue}
-        inspect_result = self.app.control.inspect(active_workers)
-        active_queues_by_worker = (
-            inspect_result.active_queues() if inspect_result else None
-        )
-        if not active_queues_by_worker:
-            active_queues_by_worker = {}
-
         active_queues = {
             queue.get("name")
-            for queues in active_queues_by_worker.values()
+            for queues in (
+                self.app.control.inspect(active_workers).active_queues() or {}
+            ).values()
             for queue in queues
         }
 

--- a/tests/contrib/test_celery.py
+++ b/tests/contrib/test_celery.py
@@ -158,3 +158,22 @@ class TestCelery:
 
         result = await check.get_result()
         assert result.error is None
+
+    @pytest.mark.asyncio
+    async def test_check_status__none_active_queues(self):
+        """Treat None from inspect.active_queues() as no active queues."""
+        mock_app = mock.MagicMock()
+        mock_app.conf.task_queues = [Queue("default", routing_key="default")]
+        mock_app.conf.task_default_queue = "default"
+        mock_app.control.ping.return_value = [{"celery@worker1": {"ok": "pong"}}]
+        mock_inspect = mock.MagicMock()
+        mock_inspect.active_queues.return_value = None
+        mock_app.control.inspect.return_value = mock_inspect
+
+        check = CeleryPingHealthCheck()
+        check.app = mock_app
+
+        result = await check.get_result()
+        assert result.error is not None
+        assert isinstance(result.error, ServiceUnavailable)
+        assert "default" in str(result.error)


### PR DESCRIPTION
Fixes #699

`inspect(...).active_queues()` can return `None` when the broker is restarting. This makes `check_active_queues()` handle a missing inspect payload as an empty queue mapping, so it reports unavailable queues instead of crashing with `AttributeError`.

Added a regression test for the `None` return path.

Greetings, saschabuehrle
