### PR TITLE
Ref #701 -- Close dangling DB connections and reduce memory foodprint

### DIFF
--- a/health_check/base.py
+++ b/health_check/base.py
@@ -74,11 +74,12 @@ class HealthCheck(abc.ABC):
         return "OK"
 
     async def get_result(self: HealthCheck) -> HealthCheckResult:
+        loop = asyncio.get_running_loop()
         start = timeit.default_timer()
         try:
             await self.run() if inspect.iscoroutinefunction(
                 self.run
-            ) else await asyncio.to_thread(self.run)
+            ) else await loop.run_in_executor(None, self.run)
         except HealthCheckException as e:
             error = e
         except BaseException:

--- a/health_check/checks.py
+++ b/health_check/checks.py
@@ -118,12 +118,11 @@ class Database(HealthCheck):
             connection = connections[self.alias]
         except ConnectionDoesNotExist as e:
             raise ServiceUnavailable("Database alias does not exist") from e
-        result = None
         try:
             compiler = connection.ops.compiler("SQLCompiler")(
                 _SelectOne(), connection, None
             )
-            with connection.cursor() as cursor:
+            with connection.temporary_connection() as cursor:
                 cursor.execute(*compiler.compile(_SelectOne()))
                 result = cursor.fetchone()
         except db.Error as e:
@@ -133,8 +132,6 @@ class Database(HealthCheck):
                 raise ServiceUnavailable(
                     "Health Check query did not return the expected result."
                 )
-        finally:
-            connection.close_if_unusable_or_obsolete()
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
- **Ref #701 -- Do not copy context to threads**
- **Ref #701 -- Use temporary connection in DB check**
