### PR TITLE
Resolve #724 -- Add public dataclass field as OpenMetric label

### DIFF
--- a/health_check/base.py
+++ b/health_check/base.py
@@ -74,15 +74,15 @@ class HealthCheck(abc.ABC):
         """Return a human-readable status string, always 'OK' for the check itself."""
         return "OK"
 
-    def json_label(self) -> dict[str, str]:
-        """Return a label dict built from dataclass fields with ``repr=True``."""
+    @property
+    def labels(self) -> dict[str, str]:
+        """Return a human-readable label for the check, defaulting to the class name."""
         return {
-            "check": type(self).__name__,
-            **{
-                field.name: str(getattr(self, field.name))
-                for field in dataclasses.fields(self)
-                if field.repr
-            },
+            "check": self.__class__.__name__,
+        } | {
+            field.name: str(getattr(self, field.name))
+            for field in dataclasses.fields(self)
+            if field.repr
         }
 
     async def get_result(self, executor: Executor | None = None) -> HealthCheckResult:

--- a/health_check/base.py
+++ b/health_check/base.py
@@ -80,9 +80,9 @@ class HealthCheck(abc.ABC):
         return {
             "check": self.__class__.__name__,
         } | {
-            field.name: str(getattr(self, field.name))
+            field.name: str(value)
             for field in dataclasses.fields(self)
-            if field.repr
+            if field.repr and (value := getattr(self, field.name)) is not None
         }
 
     async def get_result(self, executor: Executor | None = None) -> HealthCheckResult:

--- a/health_check/base.py
+++ b/health_check/base.py
@@ -74,6 +74,17 @@ class HealthCheck(abc.ABC):
         """Return a human-readable status string, always 'OK' for the check itself."""
         return "OK"
 
+    def json_label(self) -> dict[str, str]:
+        """Return a label dict built from dataclass fields with ``repr=True``."""
+        return {
+            "check": type(self).__name__,
+            **{
+                field.name: str(getattr(self, field.name))
+                for field in dataclasses.fields(self)
+                if field.repr
+            },
+        }
+
     async def get_result(self, executor: Executor | None = None) -> HealthCheckResult:
         loop = asyncio.get_running_loop()
         start = timeit.default_timer()

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -219,7 +219,8 @@ class HealthCheckView(TemplateView):
         return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
 
     @staticmethod
-    def abnf_dump(o: dict[str, str]):
+    def abnf_dumps(o: dict[str, str]):
+        """Return ABNF OpenMetic labels as a string suitable for use in a metric name."""
         return ",".join(
             f'{key}="{HealthCheckView.abnf_escape(value)}"' for key, value in o.items()
         )
@@ -236,7 +237,7 @@ class HealthCheckView(TemplateView):
         for result in self.results:
             has_errors |= bool(result.error)
             lines.append(
-                f"django_health_check_status{{{self.abnf_dump(result.check.labels)}}} {not result.error:d}"
+                f"django_health_check_status{{{self.abnf_dumps(result.check.labels)}}} {not result.error:d}"
             )
 
         # Add response time metrics
@@ -248,7 +249,7 @@ class HealthCheckView(TemplateView):
 
         for result in self.results:
             lines.append(
-                f"django_health_check_response_time_seconds{{{self.abnf_dump(result.check.labels)}}} {result.time_taken:.6f}"
+                f"django_health_check_response_time_seconds{{{self.abnf_dumps(result.check.labels)}}} {result.time_taken:.6f}"
             )
 
         # Add overall health status

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -1,7 +1,6 @@
 import asyncio
 import contextlib
 import datetime
-import json
 import re
 import typing
 from concurrent.futures import Executor
@@ -208,12 +207,21 @@ class HealthCheckView(TemplateView):
         return self._render_feed(Rss201rev2Feed)
 
     @staticmethod
-    def _openmetrics_labels(check):
-        """Format a ``HealthCheck.json_label()`` dict as an OpenMetrics label set."""
-        return (
-            "{"
-            + ",".join(f"{k}={json.dumps(v)}" for k, v in check.json_label().items())
-            + "}"
+    def abnf_escape(value):
+        r"""
+        Escape ABNF OpenMetic labels according to RFC 5234 and RFC7405.
+
+        Escapes backslashes, double quotes, and newlines as required by the spec:
+        - Backslash (\) -> \\
+        - Double quote (") -> \"
+        - Line feed (\n) -> \n
+        """
+        return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+    @staticmethod
+    def abnf_dump(o: dict[str, str]):
+        return ",".join(
+            f'{key}="{HealthCheckView.abnf_escape(value)}"' for key, value in o.items()
         )
 
     def render_to_response_openmetrics(self):
@@ -226,9 +234,10 @@ class HealthCheckView(TemplateView):
 
         # Add status metrics for each check
         for result in self.results:
-            labels = self._openmetrics_labels(result.check)
             has_errors |= bool(result.error)
-            lines.append(f"django_health_check_status{labels} {not result.error:d}")
+            lines.append(
+                f"django_health_check_status{{{self.abnf_dump(result.check.labels)}}} {not result.error:d}"
+            )
 
         # Add response time metrics
         lines += [
@@ -238,9 +247,8 @@ class HealthCheckView(TemplateView):
         ]
 
         for result in self.results:
-            labels = self._openmetrics_labels(result.check)
             lines.append(
-                f"django_health_check_response_time_seconds{labels} {result.time_taken:.6f}"
+                f"django_health_check_response_time_seconds{{{self.abnf_dump(result.check.labels)}}} {result.time_taken:.6f}"
             )
 
         # Add overall health status

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import dataclasses
 import datetime
 import re
 import typing
@@ -217,6 +218,17 @@ class HealthCheckView(TemplateView):
         """
         return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
 
+    def _openmetrics_labels(self, check):
+        """Build OpenMetrics label set from a HealthCheck dataclass instance."""
+        escape = self._escape_openmetrics_label_value
+        parts = [f'check="{escape(check.__class__.__name__)}"']
+        for field in dataclasses.fields(check):
+            if field.repr:
+                parts.append(
+                    f'{field.name}="{escape(str(getattr(check, field.name)))}"'
+                )
+        return "{" + ",".join(parts) + "}"
+
     def render_to_response_openmetrics(self):
         """Return OpenMetrics response with health check results."""
         lines = [
@@ -227,11 +239,9 @@ class HealthCheckView(TemplateView):
 
         # Add status metrics for each check
         for result in self.results:
-            safe_label = self._escape_openmetrics_label_value(repr(result.check))
+            labels = self._openmetrics_labels(result.check)
             has_errors |= bool(result.error)
-            lines.append(
-                f'django_health_check_status{{check="{safe_label}"}} {not result.error:d}'
-            )
+            lines.append(f"django_health_check_status{labels} {not result.error:d}")
 
         # Add response time metrics
         lines += [
@@ -241,9 +251,9 @@ class HealthCheckView(TemplateView):
         ]
 
         for result in self.results:
-            safe_label = self._escape_openmetrics_label_value(repr(result.check))
+            labels = self._openmetrics_labels(result.check)
             lines.append(
-                f'django_health_check_response_time_seconds{{check="{safe_label}"}} {result.time_taken:.6f}'
+                f"django_health_check_response_time_seconds{labels} {result.time_taken:.6f}"
             )
 
         # Add overall health status

--- a/health_check/views.py
+++ b/health_check/views.py
@@ -1,7 +1,7 @@
 import asyncio
 import contextlib
-import dataclasses
 import datetime
+import json
 import re
 import typing
 from concurrent.futures import Executor
@@ -207,27 +207,14 @@ class HealthCheckView(TemplateView):
         """Return RSS 2.0 feed response with health check results."""
         return self._render_feed(Rss201rev2Feed)
 
-    def _escape_openmetrics_label_value(self, value):
-        r"""
-        Escape label value according to OpenMetrics specification.
-
-        Escapes backslashes, double quotes, and newlines as required by the spec:
-        - Backslash (\) -> \\
-        - Double quote (") -> \"
-        - Line feed (\n) -> \n
-        """
-        return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
-
-    def _openmetrics_labels(self, check):
-        """Build OpenMetrics label set from a HealthCheck dataclass instance."""
-        escape = self._escape_openmetrics_label_value
-        parts = [f'check="{escape(check.__class__.__name__)}"']
-        for field in dataclasses.fields(check):
-            if field.repr:
-                parts.append(
-                    f'{field.name}="{escape(str(getattr(check, field.name)))}"'
-                )
-        return "{" + ",".join(parts) + "}"
+    @staticmethod
+    def _openmetrics_labels(check):
+        """Format a ``HealthCheck.json_label()`` dict as an OpenMetrics label set."""
+        return (
+            "{"
+            + ",".join(f"{k}={json.dumps(v)}" for k, v in check.json_label().items())
+            + "}"
+        )
 
     def render_to_response_openmetrics(self):
         """Return OpenMetrics response with health check results."""

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -102,6 +102,7 @@ class TestHealthCheck:
             foo: str = "bar"
             version: float = 1.0
             secret_key: str = dataclasses.field(default="secret", repr=False)
+            missing_value: str | None = None
 
             async def run(self):
                 pass

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,4 +1,5 @@
 import asyncio
+import dataclasses
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -92,3 +93,18 @@ class TestHealthCheck:
         check = SlowCheck()
         result = await check.get_result()
         assert result.time_taken > 0
+
+    def test_labels(self):
+        """Labels include class name and dataclass fields, excluding secret fields."""
+
+        @dataclasses.dataclass
+        class LabeledCheck(HealthCheck):
+            foo: str = "bar"
+            version: float = 1.0
+            secret_key: str = dataclasses.field(default="secret", repr=False)
+
+            async def run(self):
+                pass
+
+        check = LabeledCheck()
+        assert check.labels == {"check": "LabeledCheck", "foo": "bar", "version": "1.0"}

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1069,3 +1069,17 @@ class TestHealthCheckView:
         if hasattr(response, "render"):
             response.render()
         assert response.status_code == 200
+
+    def test_abnf_escape(self):
+        assert HealthCheckView.abnf_escape("simple") == "simple"
+        assert (
+            HealthCheckView.abnf_escape(r"backslash\backslash")
+            == "backslash\\\\backslash"
+        )
+        assert HealthCheckView.abnf_escape('quote"test') == 'quote\\"test'
+        assert HealthCheckView.abnf_escape("line\nbreak") == "line\\nbreak"
+
+    def test_abnf_dumps(self):
+        assert HealthCheckView.abnf_dumps({"a": "b"}) == 'a="b"'
+        assert HealthCheckView.abnf_dumps({"a": "b", "c": "d"}) == 'a="b",c="d"'
+        assert HealthCheckView.abnf_dumps({"a": 'b"c'}) == 'a="b\\"c"'

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -914,6 +914,7 @@ class TestHealthCheckView:
         response = await health_check_view([CustomCheck], format_param="openmetrics")
         content = response.content.decode("utf-8")
         # Check that the label value is present (with proper escaping)
+        print(content)
         assert 'check="CustomCheck",name="Custom-Check.Backend Test"' in content
 
     @pytest.mark.asyncio

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -914,7 +914,6 @@ class TestHealthCheckView:
         response = await health_check_view([CustomCheck], format_param="openmetrics")
         content = response.content.decode("utf-8")
         # Check that the label value is present (with proper escaping)
-        print(content)
         assert 'check="CustomCheck",name="Custom-Check.Backend Test"' in content
 
     @pytest.mark.asyncio

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -906,16 +906,15 @@ class TestHealthCheckView:
 
         @dataclasses.dataclass
         class CustomCheck(HealthCheck):
+            name: str = "Custom-Check.Backend Test"
+
             async def run(self):
                 pass
-
-            def __repr__(self):
-                return "Custom-Check.Backend Test"
 
         response = await health_check_view([CustomCheck], format_param="openmetrics")
         content = response.content.decode("utf-8")
         # Check that the label value is present (with proper escaping)
-        assert 'check="Custom-Check.Backend Test"' in content
+        assert 'check="CustomCheck",name="Custom-Check.Backend Test"' in content
 
     @pytest.mark.asyncio
     async def test_get__openmetrics_label_escaping(self, health_check_view):
@@ -923,11 +922,10 @@ class TestHealthCheckView:
 
         @dataclasses.dataclass
         class EscapingCheck(HealthCheck):
+            name: str = 'Test "quoted" value\\with\\backslashes\nand newlines'
+
             async def run(self):
                 pass
-
-            def __repr__(self):
-                return 'Test "quoted" value\\with\\backslashes\nand newlines'
 
         response = await health_check_view([EscapingCheck], format_param="openmetrics")
         content = response.content.decode("utf-8")


### PR DESCRIPTION
Closes #724 

With openmetrics format, make the "check" label as the name class, and take all fields (that have repr=True) as a metric label.