### PR TITLE
Update deprecated redis_url test case

### DIFF
--- a/tests/contrib/test_redis.py
+++ b/tests/contrib/test_redis.py
@@ -4,6 +4,7 @@ import os
 from unittest import mock
 
 import pytest
+from django.urls import reverse
 
 pytest.importorskip("redis")
 
@@ -16,6 +17,18 @@ from health_check.exceptions import ServiceUnavailable
 
 class TestRedis:
     """Test Redis health check."""
+
+    def test_redis__testapp_route_uses_current_constructor_contract(self, client):
+        """The test app Redis route instantiates the check with client_factory."""
+        with mock.patch(
+            "health_check.contrib.redis.Redis.run",
+            new=mock.AsyncMock(return_value=None),
+        ):
+            response = client.get(f"{reverse('health_check_redis')}?format=text")
+
+        assert response.status_code == 200
+        assert b"Redis(" in response.content
+        assert b"OK" in response.content
 
     @pytest.mark.asyncio
     async def test_redis__ok(self):

--- a/tests/contrib/test_redis.py
+++ b/tests/contrib/test_redis.py
@@ -4,8 +4,6 @@ import os
 from unittest import mock
 
 import pytest
-from django.conf import settings
-from django.urls import reverse
 
 pytest.importorskip("redis")
 
@@ -18,29 +16,6 @@ from health_check.exceptions import ServiceUnavailable
 
 class TestRedis:
     """Test Redis health check."""
-
-    def test_redis__testapp_route_uses_current_constructor_contract(self, client):
-        """The test app Redis route instantiates the check with client_factory."""
-        mock_client = mock.AsyncMock()
-        mock_client.ping.return_value = True
-        mock_client.connection_pool.connection_kwargs = {
-            "host": "localhost",
-            "port": 6379,
-            "db": 1,
-        }
-
-        with mock.patch(
-            "tests.testapp.urls.RedisClient.from_url", return_value=mock_client
-        ) as mock_from_url:
-            response = client.get(f"{reverse('health_check_redis')}?format=text")
-
-        assert response.status_code == 200
-        assert b"Redis(" in response.content
-        assert b"OK" in response.content
-        assert mock_from_url.call_count == 2
-        mock_from_url.assert_called_with(settings.REDIS_URL)
-        mock_client.ping.assert_awaited_once()
-        mock_client.aclose.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_redis__ok(self):

--- a/tests/contrib/test_redis.py
+++ b/tests/contrib/test_redis.py
@@ -4,6 +4,7 @@ import os
 from unittest import mock
 
 import pytest
+from django.conf import settings
 from django.urls import reverse
 
 pytest.importorskip("redis")
@@ -20,15 +21,26 @@ class TestRedis:
 
     def test_redis__testapp_route_uses_current_constructor_contract(self, client):
         """The test app Redis route instantiates the check with client_factory."""
+        mock_client = mock.AsyncMock()
+        mock_client.ping.return_value = True
+        mock_client.connection_pool.connection_kwargs = {
+            "host": "localhost",
+            "port": 6379,
+            "db": 1,
+        }
+
         with mock.patch(
-            "health_check.contrib.redis.Redis.run",
-            new=mock.AsyncMock(return_value=None),
-        ):
+            "tests.testapp.urls.RedisClient.from_url", return_value=mock_client
+        ) as mock_from_url:
             response = client.get(f"{reverse('health_check_redis')}?format=text")
 
         assert response.status_code == 200
         assert b"Redis(" in response.content
         assert b"OK" in response.content
+        assert mock_from_url.call_count == 2
+        mock_from_url.assert_called_with(settings.REDIS_URL)
+        mock_client.ping.assert_awaited_once()
+        mock_client.aclose.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_redis__ok(self):

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -53,10 +53,13 @@ else:
     )
 
 try:
-    import redis  # noqa: F401
+    from redis.asyncio import Redis as RedisClient
 except ImportError:
     pass
 else:
+    def redis_client_factory():
+        return RedisClient.from_url(settings.REDIS_URL)
+
     urlpatterns.append(
         path(
             "health/redis/",
@@ -64,7 +67,7 @@ else:
                 checks=[
                     (
                         "health_check.contrib.redis.Redis",
-                        {"redis_url": settings.REDIS_URL},
+                        {"client_factory": redis_client_factory},
                     )
                 ]
             ),

--- a/tests/testapp/urls.py
+++ b/tests/testapp/urls.py
@@ -57,6 +57,7 @@ try:
 except ImportError:
     pass
 else:
+
     def redis_client_factory():
         return RedisClient.from_url(settings.REDIS_URL)
 


### PR DESCRIPTION
The test app Redis endpoint was still passing redis_url into the check, but the Redis check now expects client_factory or the deprecated client argument. That made /health/redis/ blow up before the check even ran.

This switches the test route to client_factory and adds a regression test that hits the route and makes sure it returns a normal health response.

Tests:
uv run pytest -q tests/contrib/test_redis.py
uv run pytest -q tests/test_management.py tests/test_views.py
uvx ruff check tests/testapp/urls.py tests/contrib/test_redis.py