### PR TITLE
Add alias support for Redis metrics labels

### DIFF
--- a/health_check/contrib/redis.py
+++ b/health_check/contrib/redis.py
@@ -45,7 +45,7 @@ class Redis(HealthCheck):
         >>> Redis(client_factory=lambda: Sentinel([('localhost', 26379)]).master_for('mymaster'))
 
     """
-
+    alias: str | None = None
     client: RedisClient | RedisCluster | None = dataclasses.field(
         repr=False, default=None
     )

--- a/health_check/contrib/redis.py
+++ b/health_check/contrib/redis.py
@@ -45,6 +45,7 @@ class Redis(HealthCheck):
         >>> Redis(client_factory=lambda: Sentinel([('localhost', 26379)]).master_for('mymaster'))
 
     """
+
     alias: str | None = None
     client: RedisClient | RedisCluster | None = dataclasses.field(
         repr=False, default=None

--- a/tests/contrib/test_redis.py
+++ b/tests/contrib/test_redis.py
@@ -312,3 +312,19 @@ class TestRedis:
         check = RedisHealthCheck(client_factory=factory)
         result = await check.get_result()
         assert result.error is None
+
+    def test_redis__labels_include_alias(self):
+        """Verify labels include alias when provided."""
+        mock_client = mock.AsyncMock()
+
+        check = RedisHealthCheck(
+            alias="channels",
+            client_factory=lambda: mock_client,
+        )
+
+        assert check.labels == {
+            "check": "Redis",
+            "alias": "channels",
+        }
+        assert "client" not in check.labels
+        assert "client_factory" not in check.labels


### PR DESCRIPTION
## Summary

This PR adds optional `alias` support to the Redis health check so that multiple Redis instances can be distinguished in OpenMetrics labels.

Previously, when multiple Redis health checks were configured, they all produced the same label:

```text
django_health_check_status{check="Redis"} 1
```

With this change, users can provide an `alias` to uniquely identify each Redis check:

```python
checks = [
    (
        "health_check.contrib.redis.Redis",
        {
            "alias": "channels",
            "client_factory": lambda: RedisClient.from_url(settings.CHANNELS_REDIS_URL),
        },
    ),
    (
        "health_check.contrib.redis.Redis",
        {
            "alias": "constance",
            "client_factory": lambda: RedisClient.from_url(settings.CONSTANCE_REDIS_URL),
        },
    ),
]
```

Resulting labels:

```text
django_health_check_status{check="Redis",alias="channels"} 1
django_health_check_status{check="Redis",alias="constance"} 1
```

## Changes

- Added an optional `alias` field to `health_check.contrib.redis.Redis`.
- The alias is automatically included in the generated labels when provided.
- Added a regression test verifying that `labels` includes the configured alias.
- Existing behavior remains unchanged when no alias is specified.

## Testing

- Added a regression test for alias labels.
- Ran the Redis test suite successfully (`18 passed, 2 skipped`).
- Manually verified that multiple Redis instances configured with different aliases produce distinct labels.
<img width="948" height="707" alt="Screenshot 2026-07-23 195817" src="https://github.com/user-attachments/assets/fdfdad3f-109a-4300-9561-c7e63eed9bad" />
