### PR TITLE
feat: log failed health checks

### DIFF
--- a/health_check/base.py
+++ b/health_check/base.py
@@ -94,6 +94,7 @@ class HealthCheck(abc.ABC):
             ) else await loop.run_in_executor(executor, self.run)
         except HealthCheckException as e:
             error = e
+            logger.warning("Health check %s failed: %s", self.__class__.__name__, error)
         except BaseException:
             logger.exception("Unexpected exception during health check")
             error = HealthCheckException("unknown error")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,11 +1,12 @@
 import asyncio
 import dataclasses
+import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from health_check.base import HealthCheck, HealthCheckResult
-from health_check.exceptions import HealthCheckException
+from health_check.exceptions import HealthCheckException, ServiceUnavailable
 
 
 class TestHealthCheck:
@@ -36,6 +37,21 @@ class TestHealthCheck:
         assert result.error is not None
         assert isinstance(result.error, HealthCheckException)
         assert str(result.error) == "Unknown Error: unknown error"
+
+    @pytest.mark.asyncio
+    async def test_get_result__log_handled_failure(self, caplog):
+        """Log handled failure at warning level."""
+
+        class UnavailableCheck(HealthCheck):
+            async def run(self):
+                raise ServiceUnavailable("test service unavailable")
+
+        caplog.set_level(logging.WARNING, logger="health_check.base")
+        await UnavailableCheck().get_result()
+
+        assert caplog.messages == [
+            "Health check UnavailableCheck failed: Unavailable: test service unavailable"
+        ]
 
     @pytest.mark.asyncio
     async def test_run__sync_check(self):


### PR DESCRIPTION
Fixes #747

## Summary

- log handled `HealthCheckException` failures through the shared `health_check.base` logger at WARNING level
- include the failing check class and returned health-check error in the log message
- add regression coverage for the warning record

## Verification

- `uv run pytest tests/test_base.py -q` — 8 passed
- `uv tool run pre-commit run --files health_check/base.py tests/test_base.py` — passed

I also ran the full `uv run pytest` suite. It completed with 158 passed and 26 skipped, plus one existing environment-sensitive DNS assertion: this Windows network returns `no answer` for the test's unroutable resolver (`192.0.2.1`), while the test only accepts messages containing `timeout` or `nameserver`. Rerunning that test reproduces the same unrelated result; this PR does not alter DNS behavior.

AI assistance was used to investigate and draft this focused change; the resulting code and tests were reviewed and verified locally.
