### PR TITLE
Fix #755 -- Recycle stale database connections before probing

### DIFF
--- a/health_check/checks.py
+++ b/health_check/checks.py
@@ -118,6 +118,12 @@ class Database(HealthCheck):
             connection = connections[self.alias]
         except ConnectionDoesNotExist as e:
             raise ServiceUnavailable("Database alias does not exist") from e
+        # Synchronous checks run on the event loop's default executor, whose threads sit
+        # outside the request/response cycle where Django recycles connections. Without
+        # this, temporary_connection() reuses whatever connection the thread already
+        # holds, even one the server has dropped in the meantime, and the check reports
+        # a failure for a database that is perfectly healthy.
+        connection.close_if_unusable_or_obsolete()
         try:
             compiler = connection.ops.compiler("SQLCompiler")(
                 _SelectOne(), connection, None

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -141,6 +141,33 @@ class TestDatabase:
         result = await check.get_result()
         assert result.error is None
 
+    @pytest.mark.django_db
+    @pytest.mark.asyncio
+    async def test_run_check__stale_connection(self):
+        """Recycle a connection the database has already dropped."""
+        with mock.patch("health_check.checks.connections") as mock_connections:
+            mock_connection = mock_connections.__getitem__.return_value
+            mock_connection.temporary_connection.side_effect = db.Error(
+                "the connection is closed"
+            )
+            mock_connection.ops.compiler.return_value = mock.MagicMock(
+                return_value=mock.MagicMock(compile=lambda x: ("SELECT 1", []))
+            )
+
+            def revive_connection():
+                mock_connection.temporary_connection.side_effect = None
+                mock_connection.temporary_connection.return_value.__enter__.return_value.fetchone.return_value = (
+                    1,
+                )
+
+            mock_connection.close_if_unusable_or_obsolete.side_effect = (
+                revive_connection
+            )
+
+            assert (await Database().get_result()).error is None, (
+                "Expected the check to recycle the stale connection before probing"
+            )
+
 
 class TestDNS:
     """Test the DNS health check."""


### PR DESCRIPTION
Proposed fix for https://github.com/codingjoe/django-health-check/issues/755

Basically adds a call to `close_if_unusable_or_obsolete()` so that stale connections get refreshed automatically.

More details from Claude if you want them:

---
Synchronous checks run on the event loop's default executor, whose threads sit outside the request/response cycle where Django recycles connections. `temporary_connection()` only closes a connection it opened itself, so a connection already parked on one of those threads is reused with no liveness check. Once the server drops that connection, the check reports `Unavailable: the connection is closed` for a perfectly healthy database, then self-clears when the next poll lands on a different thread.

Call `close_if_unusable_or_obsolete()` before probing, mirroring what Django does between requests and what `channels.db.DatabaseSyncToAsync` does for the same class of problem. This also makes CONN_MAX_AGE apply on those threads, where previously nothing ever aged a connection out.

Verified against a real Postgres. sqlite cannot demonstrate this, since its `is_usable()` always returns True and `:memory:` ignores `close()`:

  CONN_MAX_AGE=0                             before: FAILED  after: OK
  CONN_MAX_AGE=60, CONN_HEALTH_CHECKS=True   before: FAILED  after: OK
  CONN_MAX_AGE=60, CONN_HEALTH_CHECKS=False  before: FAILED  after: FAILED

The last row is correct behavior, not a gap. With persistent connections and health checks disabled, ordinary request traffic reuses dead connections too, so a red health check accurately reflects what users experience.