### PR TITLE
Fix #758 -- Support Django 6.1 MAILERS setting in Mail health check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,16 @@ jobs:
         django-version:
           - "5.2"
           - "6.0"
+          - "6.1"
         exclude:
           - python-version: "3.10"
             django-version: "6.0"
           - python-version: "3.11"
             django-version: "6.0"
+          - python-version: "3.10"
+            django-version: "6.1"
+          - python-version: "3.11"
+            django-version: "6.1"
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7

--- a/health_check/checks.py
+++ b/health_check/checks.py
@@ -7,9 +7,9 @@ import smtplib
 import socket
 import uuid
 
+import django
 import dns.asyncresolver
 from django import db
-from django.conf import settings
 from django.core.cache import CacheKeyWarning, caches
 from django.core.cache.backends.base import InvalidCacheBackendError
 from django.core.files.base import ContentFile
@@ -17,6 +17,12 @@ from django.core.files.storage import InvalidStorageError, storages
 from django.core.files.storage import Storage as DjangoStorage
 from django.core.mail import get_connection
 from django.core.mail.backends.base import BaseEmailBackend
+
+if django.VERSION >= (6, 1):
+    from django.core.mail import DEFAULT_MAILER_ALIAS, mailers
+else:  # Django < 6.1
+    DEFAULT_MAILER_ALIAS = "default"
+
 from django.db import connections
 from django.db.models import Expression
 from django.utils.connection import ConnectionDoesNotExist
@@ -197,18 +203,25 @@ class Mail(HealthCheck):
     Check that an email backend is able to open and close the connection.
 
     Args:
-        backend: The email backend to test against.
+        backend: The email backend to test against. Legacy, used only on Django < 6.1.
+        alias: The mailer alias to test.
         timeout: Timeout for connection to an email server in seconds.
 
     """
 
-    backend: str = settings.EMAIL_BACKEND
+    backend: str | None = dataclasses.field(default=None, repr=False)
+    alias: str = DEFAULT_MAILER_ALIAS
     timeout: datetime.timedelta = dataclasses.field(
         default=datetime.timedelta(seconds=15), repr=False
     )
 
+    def _get_connection(self) -> BaseEmailBackend:
+        if django.VERSION >= (6, 1):
+            return mailers[self.alias]
+        return get_connection(self.backend, fail_silently=False)
+
     def run(self) -> None:
-        connection: BaseEmailBackend = get_connection(self.backend, fail_silently=False)
+        connection: BaseEmailBackend = self._get_connection()
         connection.timeout = self.timeout.total_seconds()
         logger.debug("Trying to open connection to mail backend.")
         try:
@@ -221,9 +234,7 @@ class Mail(HealthCheck):
             raise ServiceUnavailable("Connection refused error") from e
         finally:
             connection.close()
-        logger.debug(
-            "Connection established. Mail backend %r is healthy.", self.backend
-        )
+        logger.debug("Connection established. Mail backend %r is healthy.", connection)
 
 
 @dataclasses.dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
   "Framework :: Django",
   "Framework :: Django :: 5.2",
   "Framework :: Django :: 6.0",
+  "Framework :: Django :: 6.1",
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Operating System :: OS Independent",

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -4,9 +4,11 @@ import datetime
 import logging
 from unittest import mock
 
+import django
 import pytest
 from django import db
 from django.core.cache import CacheKeyWarning
+from django.test import override_settings
 
 from health_check import Storage
 from health_check.checks import DNS, Cache, Database, Mail
@@ -159,9 +161,89 @@ class TestMail:
     @pytest.mark.asyncio
     async def test_run_check__locmem_backend(self):
         """Mail check completes with locmem backend."""
-        check = Mail(backend="django.core.mail.backends.locmem.EmailBackend")
-        result = await check.get_result()
-        assert result.error is None
+        with override_settings(
+            EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend"
+        ):
+            check = Mail()
+            result = await check.get_result()
+            assert result.error is None
+
+    def test_defaults(self):
+        """Mail check defaults to backend=None and DEFAULT_MAILER_ALIAS."""
+        from health_check.checks import DEFAULT_MAILER_ALIAS
+
+        check = Mail()
+        assert check.backend is None
+        assert check.alias == DEFAULT_MAILER_ALIAS
+
+    @pytest.mark.skipif(
+        django.VERSION < (6, 1),
+        reason="mailers handler requires Django 6.1+",
+    )
+    def test_get_connection__mailers_configured(self):
+        """Use the mailers handler when available."""
+        mock_connection = mock.MagicMock()
+        mock_mailers = mock.MagicMock()
+        mock_mailers.__getitem__.return_value = mock_connection
+
+        with mock.patch("health_check.checks.mailers", mock_mailers):
+            check = Mail(alias="default")
+            connection = check._get_connection()
+
+        assert connection is mock_connection
+        mock_mailers.__getitem__.assert_called_once_with("default")
+
+    @pytest.mark.skipif(
+        django.VERSION < (6, 1),
+        reason="mailers handler requires Django 6.1+",
+    )
+    def test_get_connection__mailers_custom_alias(self):
+        """Use a custom mailer alias when available."""
+        mock_connection = mock.MagicMock()
+        mock_mailers = mock.MagicMock()
+        mock_mailers.__getitem__.return_value = mock_connection
+
+        with mock.patch("health_check.checks.mailers", mock_mailers):
+            check = Mail(alias="custom")
+            connection = check._get_connection()
+
+        assert connection is mock_connection
+        mock_mailers.__getitem__.assert_called_once_with("custom")
+
+    def test_get_connection__legacy_fallback(self):
+        """Fall back to get_connection on Django < 6.1."""
+        mock_connection = mock.MagicMock()
+
+        with (
+            mock.patch("health_check.checks.django.VERSION", (5, 2)),
+            mock.patch(
+                "health_check.checks.get_connection", return_value=mock_connection
+            ) as mock_get_conn,
+        ):
+            check = Mail(backend="django.core.mail.backends.locmem.EmailBackend")
+            connection = check._get_connection()
+
+        assert connection is mock_connection
+        mock_get_conn.assert_called_once_with(
+            "django.core.mail.backends.locmem.EmailBackend",
+            fail_silently=False,
+        )
+
+    @pytest.mark.skipif(
+        django.VERSION < (6, 1),
+        reason="MAILERS requires Django 6.1+",
+    )
+    @pytest.mark.asyncio
+    async def test_run_check__mailers_integration(self):
+        """Mail check completes end-to-end with MAILERS configured."""
+        with override_settings(
+            MAILERS={
+                "default": {"BACKEND": "django.core.mail.backends.locmem.EmailBackend"}
+            }
+        ):
+            check = Mail()
+            result = await check.get_result()
+            assert result.error is None
 
 
 class TestStorage:
@@ -380,7 +462,7 @@ class TestMailExceptionHandling:
     @pytest.mark.asyncio
     async def test_check_status__success(self, caplog):
         """Successfully open and close connection logs debug message."""
-        with mock.patch("health_check.checks.get_connection") as mock_get_connection:
+        with mock.patch.object(Mail, "_get_connection") as mock_get_connection:
             mock_connection = mock.MagicMock()
             mock_get_connection.return_value = mock_connection
             mock_connection.open.return_value = None
@@ -401,7 +483,7 @@ class TestMailExceptionHandling:
         """Raise ServiceUnavailable when SMTPException is raised."""
         import smtplib
 
-        with mock.patch("health_check.checks.get_connection") as mock_get_connection:
+        with mock.patch.object(Mail, "_get_connection") as mock_get_connection:
             mock_connection = mock.MagicMock()
             mock_get_connection.return_value = mock_connection
             mock_connection.open.side_effect = smtplib.SMTPException("SMTP error")
@@ -416,7 +498,7 @@ class TestMailExceptionHandling:
     @pytest.mark.asyncio
     async def test_check_status__connection_refused_error(self):
         """Raise ServiceUnavailable when ConnectionRefusedError is raised."""
-        with mock.patch("health_check.checks.get_connection") as mock_get_connection:
+        with mock.patch.object(Mail, "_get_connection") as mock_get_connection:
             mock_connection = mock.MagicMock()
             mock_get_connection.return_value = mock_connection
             mock_connection.open.side_effect = ConnectionRefusedError(


### PR DESCRIPTION
- Change `backend` field default from `settings.EMAIL_BACKEND` to `None` (`repr=False`)
- Add `alias` field (`str = DEFAULT_MAILER_ALIAS`) for the mailer alias on Django 6.1+
- Use `django.VERSION >= (6, 1)` to conditionally import `mailers` and `DEFAULT_MAILER_ALIAS`
- Add `_get_connection()` using `mailers[self.alias]` on 6.1+, `get_connection(self.backend)` on older
- Add Django 6.1 to CI matrix and classifiers
- Add tests for both code paths and end-to-end MAILERS integration

Close #758